### PR TITLE
Fix: ExpandableText 픽스, postItem 표시 데이터 연동, 빈 데이터 ui대응 구현

### DIFF
--- a/lib/presentation/pages/home/tabs/feed/feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_tab.dart
@@ -42,28 +42,30 @@ class FeedTab extends StatelessWidget {
                       bottom: 100,
                     ),
                     separatorBuilder: (context, index) {
-                      return SizedBox(
-                        height: 25,
-                        width: double.infinity,
-                        child: Align(
-                          alignment: Alignment.bottomCenter,
-                          child: Divider(),
-                        ),
+                      return Column(
+                        children: [
+                          SizedBox(height: 8, width: double.infinity),
+                          Divider(),
+                        ],
                       );
                     },
                     itemCount: docs.length,
                     itemBuilder: (context, index) {
+                      // TODO: 클린아키텍처 적용
                       final post = docs[index].data();
                       final content = post['content'] ?? '';
                       final imageUrl = List<String>.from(
                         post['imageUrl'] ?? [],
                       );
                       final tags = List<String>.from(post['tags'] ?? []);
+                      final commentCount = post['commentCount'] ?? 0;
 
                       return PostItem(
                         content: content,
                         imageUrl: imageUrl,
                         tags: tags,
+                        commentCount: commentCount,
+                        displayComments: true,
                       );
                     },
                   );

--- a/lib/presentation/pages/home/widgets/post_item.dart
+++ b/lib/presentation/pages/home/widgets/post_item.dart
@@ -7,12 +7,16 @@ class PostItem extends StatefulWidget {
   final String content;
   final List<String> imageUrl;
   final List<String> tags;
+  final int commentCount;
+  final bool displayComments;
 
   const PostItem({
     super.key,
     required this.content,
     required this.imageUrl,
     required this.tags,
+    required this.commentCount,
+    required this.displayComments,
   });
 
   @override
@@ -28,59 +32,48 @@ class _PostItemState extends State<PostItem> {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(height: 10),
+            SizedBox(height: 12),
             _topBar(),
             SizedBox(height: 10),
             ExpandableText(widget.content, trimLines: 4),
             SizedBox(height: 10),
             _imageBox(),
-            SizedBox(height: 15),
-            SizedBox(
-              height: 30,
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                itemBuilder: (context, index) {
-                  return Container(
-                    padding: EdgeInsets.symmetric(horizontal: 30),
-                    decoration: BoxDecoration(
-                      color: Colors.grey[400],
-                      borderRadius: BorderRadius.circular(30),
+            _tagBar(),
+            // comment 개수 표시
+            // detail 페이지에서는 표시 X
+            !widget.displayComments
+                ? SizedBox.shrink()
+                : Column(
+                  children: [
+                    SizedBox(height: 15),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.chat_bubble_outline_outlined,
+                          color: Colors.grey[500],
+                          size: 20,
+                        ),
+                        SizedBox(width: 8),
+                        Text(
+                          '${widget.commentCount}',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey[700],
+                          ),
+                        ),
+                      ],
                     ),
-                    child: Center(
-                      child: Text(
-                        widget.tags[index],
-                        style: TextStyle(fontSize: 14),
-                      ),
-                    ),
-                  );
-                },
-                separatorBuilder: (context, index) => SizedBox(width: 8),
-                itemCount: widget.tags.length,
-              ),
-            ),
-            SizedBox(height: 15),
-            Row(
-              children: [
-                Icon(
-                  Icons.chat_bubble_outline_outlined,
-                  color: Colors.grey[500],
-                  size: 20,
+                  ],
                 ),
-                SizedBox(width: 8),
-                Text(
-                  '2',
-                  style: TextStyle(fontSize: 14, color: Colors.grey[700]),
-                ),
-              ],
-            ),
           ],
         ),
       ),
     );
   }
 
-  Row _topBar() {
+  Widget _topBar() {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -154,11 +147,12 @@ class _PostItemState extends State<PostItem> {
   }
 
   Widget _imageBox() {
-    if (widget.imageUrl.isEmpty) {
+    final List<String> images =
+        widget.imageUrl.where((url) => url.trim().isNotEmpty).take(3).toList();
+
+    if (images.isEmpty) {
       return const SizedBox.shrink();
     }
-
-    final List<String> images = widget.imageUrl.take(3).toList();
 
     double sizedBoxHeight = 8;
     double sizedBoxWidth = 8;
@@ -272,13 +266,41 @@ class _PostItemState extends State<PostItem> {
               ],
             );
             break;
-
           default:
             content = const SizedBox.shrink();
         }
 
-        return AspectRatio(aspectRatio: 9 / 5, child: content);
+        return Column(
+          children: [AspectRatio(aspectRatio: 9 / 5, child: content)],
+        );
       },
+    );
+  }
+
+  Widget _tagBar() {
+    final tags = widget.tags;
+    return Column(
+      children: [
+        tags.isEmpty ? SizedBox.shrink() : SizedBox(height: 15),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children:
+              tags.map((text) {
+                return Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[400],
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(text, style: const TextStyle(fontSize: 14)),
+                );
+              }).toList(),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
- ExpandableText가 setState를 반복적으로 호출해 스크롤 에러 일으키는 문제 픽스
- postItem에 표시되는 데이터 연동
- 빈 데이터에 대한 ui 대응 구현