### PR TITLE
feat: 게시글(Post)에 사용자 정보 포함 기능 추가

### DIFF
--- a/lib/data/dto/post_dto.dart
+++ b/lib/data/dto/post_dto.dart
@@ -3,6 +3,12 @@ import '../../domain/entity/post_entity.dart';
 
 class PostDto {
   final String uid;
+  final String userName;
+  final String userProfileImage;
+  final String userNativeLanguage;
+  final String userTargetLanguage;
+  final String? userDistrict;
+  final GeoPoint? userLocation;
   final String content;
   final List<String> imageUrl;
   final List<String> tags;
@@ -13,6 +19,12 @@ class PostDto {
 
   PostDto({
     required this.uid,
+    required this.userName,
+    required this.userProfileImage,
+    required this.userNativeLanguage,
+    required this.userTargetLanguage,
+    this.userDistrict,
+    this.userLocation,
     required this.content,
     required this.imageUrl,
     required this.tags,
@@ -25,6 +37,13 @@ class PostDto {
   factory PostDto.fromMap(Map<String, dynamic> map) {
     return PostDto(
       uid: map['uid'] ?? '',
+      userName: map['userName'] ?? '',
+      userProfileImage: map['userProfileImage'] ?? '',
+      userNativeLanguage: map['userNativeLanguage'] ?? '',
+      userTargetLanguage: map['userTargetLanguage'] ?? '',
+      userDistrict: map['userDistrict'],
+      userLocation: map['userLocation'] as GeoPoint?,
+
       content: map['content'] ?? '',
       imageUrl: List<String>.from(map['imageUrl'] ?? []),
 
@@ -40,6 +59,13 @@ class PostDto {
     return {
       'uid': uid,
       'authorId': uid,
+      'userName': userName,
+      'userProfileImage': userProfileImage,
+      'userNativeLanguage': userNativeLanguage,
+      'userTargetLanguage': userTargetLanguage,
+      'userDistrict': userDistrict,
+      'userLocation': userLocation,
+
       'content': content,
       'imageUrl': imageUrl,
       'tags': tags,
@@ -53,6 +79,13 @@ class PostDto {
   PostEntity toEntity() {
     return PostEntity(
       uid: uid,
+      userName: userName,
+      userProfileImage: userProfileImage,
+      userNativeLanguage: userNativeLanguage,
+      userTargetLanguage: userTargetLanguage,
+      userDistrict: userDistrict,
+      userLocation: userLocation,
+
       content: content,
       imageUrl: imageUrl,
       tags: tags,
@@ -66,6 +99,13 @@ class PostDto {
   static PostDto fromEntity(PostEntity entity) {
     return PostDto(
       uid: entity.uid,
+      userName: entity.userName,
+      userProfileImage: entity.userProfileImage,
+      userNativeLanguage: entity.userNativeLanguage,
+      userTargetLanguage: entity.userTargetLanguage,
+      userDistrict: entity.userDistrict,
+      userLocation: entity.userLocation,
+
       content: entity.content,
       imageUrl: entity.imageUrl,
       tags: entity.tags,

--- a/lib/domain/entity/post_entity.dart
+++ b/lib/domain/entity/post_entity.dart
@@ -1,5 +1,13 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class PostEntity {
   final String uid;
+  final String userName;
+  final String userProfileImage;
+  final String userNativeLanguage;
+  final String userTargetLanguage;
+  final String? userDistrict;
+  final GeoPoint? userLocation;
   final String content;
   final List<String> imageUrl;
   final List<String> tags;
@@ -10,6 +18,12 @@ class PostEntity {
 
   PostEntity({
     required this.uid,
+    required this.userName,
+    required this.userProfileImage,
+    required this.userNativeLanguage,
+    required this.userTargetLanguage,
+    this.userDistrict,
+    this.userLocation,
     required this.content,
     required this.imageUrl,
     required this.tags,

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -98,6 +98,7 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
       final postNotifier = ref.read(postWriteViewModelProvider.notifier);
 
       await postNotifier.submitPost(
+        ref: ref,
         uid: uid,
         content: content,
         tags: _selectedTags.map((tag) => tag.replaceAll('#', '')).toList(),

--- a/lib/presentation/pages/home/tabs/write/post_write_view_model.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_view_model.dart
@@ -6,6 +6,7 @@ import 'package:share_lingo/core/providers/data_providers.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/domain/usecase/create_post_usecase.dart';
 import 'package:share_lingo/domain/usecase/upload_image_usecase.dart';
+import 'package:share_lingo/presentation/user_global_view_model.dart';
 
 class PostWriteViewModel extends StateNotifier<AsyncValue<void>> {
   final CreatePostUseCase createPostUseCase;
@@ -17,6 +18,7 @@ class PostWriteViewModel extends StateNotifier<AsyncValue<void>> {
   }) : super(const AsyncData(null));
 
   Future<void> submitPost({
+    required WidgetRef ref,
     required String uid,
     required String content,
     required List<String> tags,
@@ -25,14 +27,29 @@ class PostWriteViewModel extends StateNotifier<AsyncValue<void>> {
     state = const AsyncLoading();
 
     try {
+      // 사용자 정보 가져오기
+      final user = ref.read(userGlobalViewModelProvider);
+      if (user == null) {
+        state = AsyncError("유저 정보 없음", StackTrace.current);
+        return;
+      }
+
+      // 이미지 업로드
       final imageUrls = await Future.wait(
         imageBytesList.map(
           (imageBytes) => uploadImageUseCase(uid: uid, imageBytes: imageBytes),
         ),
       );
 
+      // PostEntity 생성
       final post = PostEntity(
         uid: uid,
+        userName: user.name,
+        userProfileImage: user.profileImage ?? '',
+        userNativeLanguage: user.nativeLanguage ?? '',
+        userTargetLanguage: user.targetLanguage ?? '',
+        userDistrict: user.district,
+        userLocation: user.location,
         content: content,
         imageUrl: imageUrls,
         tags: tags,
@@ -42,6 +59,7 @@ class PostWriteViewModel extends StateNotifier<AsyncValue<void>> {
         deleted: false,
       );
 
+      // 포스트 저장
       await createPostUseCase(post);
       state = const AsyncData(null);
     } catch (e, st) {


### PR DESCRIPTION
- 게시글(PostEntity, PostDto)에 작성자 정보(userName, userProfileImage 등) 필드 추가
- 글 작성 시 userGlobalViewModel에서 사용자 정보 가져와 Firestore에 함께 저장
- PostWriteViewModel.submitPost()에서 사용자 정보 포함하도록 로직 수정
- PostWriteTab에서 submitPost 호출 시 ref 전달 추가
- PostDto의 toMap/fromMap, toEntity/fromEntity에 필드 매핑 로직 반영