### PR TITLE
프로필 페이지에 사용자의 게시물 추가 (수정, 삭제, 신고 가능)

### DIFF
--- a/lib/domain/usecase/fetch_posts_by_uid_usecase.dart
+++ b/lib/domain/usecase/fetch_posts_by_uid_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_lingo/core/providers/data_providers.dart';
+import 'package:share_lingo/domain/entity/post_entity.dart';
+import 'package:share_lingo/domain/repository/post_repository.dart';
+
+class FetchPostsByUidUsecase {
+  final PostRepository repository;
+
+  FetchPostsByUidUsecase(this.repository);
+
+  Future<List<PostEntity>> execute(String uid) async {
+    return await repository.fetchPostsByUid(uid);
+  }
+}
+
+final fetchPostsByUidUsecaseProvider = Provider(
+      (ref) => FetchPostsByUidUsecase(ref.read(postRepositoryProvider)),
+);

--- a/lib/presentation/pages/home/tabs/feed/feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_tab.dart
@@ -7,33 +7,34 @@ import 'package:share_lingo/presentation/pages/home/widgets/post_item.dart';
 import '../../../../../app/constants/app_colors.dart';
 
 class FeedTab extends StatelessWidget {
-  const FeedTab({super.key});
+  final String? uid;
+
+  const FeedTab({super.key, this.uid});
 
   @override
   Widget build(BuildContext context) {
     return Consumer(
       builder: (context, ref, child) {
-        final feedAsync = ref.watch(feedNotifierProvider);
+        final feedAsync = ref.watch(feedNotifierProvider(uid));
 
         return Column(
           children: [
-            AppBar(
-              title: Text(
-                'ShareLingo',
-                style: TextStyle(
-                  color: AppColors.primary,
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
+            if (uid == null)
+              AppBar(
+                title: Text(
+                  'ShareLingo',
+                  style: TextStyle(
+                    color: AppColors.primary,
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ),
-            ),
-
             Expanded(
               child: feedAsync.when(
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (err, _) => Center(child: Text('에러 발생: $err')),
-                data: (data) {
-                  final posts = data;
+                data: (posts) {
                   if (posts.isEmpty) {
                     return const Center(child: Text('게시글이 없습니다.'));
                   }
@@ -41,7 +42,11 @@ class FeedTab extends StatelessWidget {
                   final throttler = Throttler(
                     duration: Duration(seconds: 1),
                     callback: () {
-                      ref.read(feedNotifierProvider.notifier).fetchOlderPosts();
+                      if (uid == null) {
+                        ref
+                            .read(feedNotifierProvider(uid).notifier)
+                            .fetchOlderPosts();
+                      }
                     },
                   );
                   // 무한 스크롤
@@ -58,15 +63,17 @@ class FeedTab extends StatelessWidget {
                     // 당겨서 새로고침
                     child: RefreshIndicator(
                       onRefresh: () {
-                        final throttler = Throttler(
-                          duration: Duration(seconds: 1),
-                          callback: () {
-                            ref
-                                .read(feedNotifierProvider.notifier)
-                                .fetchLatestPosts();
-                          },
-                        );
-                        throttler.run();
+                        if (uid == null) {
+                          final throttler = Throttler(
+                            duration: Duration(seconds: 1),
+                            callback: () {
+                              ref
+                                  .read(feedNotifierProvider(uid).notifier)
+                                  .fetchLatestPosts();
+                            },
+                          );
+                          throttler.run();
+                        }
                         return Future.value();
                       },
 

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -15,8 +15,11 @@ import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/submit_bu
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/tag_row_button.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/yolo_detection.dart';
 
+import '../../../../user_global_view_model.dart';
+
 class PostWriteTab extends ConsumerStatefulWidget {
   const PostWriteTab({super.key, this.post});
+
   final PostEntity? post;
 
   @override
@@ -85,7 +88,7 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
 
       final objects = _yoloModel.runInference(image);
       final hasPerson = objects.any(
-            (e) => _yoloModel.label(e.labelIndex).toLowerCase() == 'person',
+        (e) => _yoloModel.label(e.labelIndex).toLowerCase() == 'person',
       );
 
       if (hasPerson) {
@@ -115,7 +118,7 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
 
     final newImageUrls = await Future.wait(
       _selectedImages.map(
-            (bytes) => ref
+        (bytes) => ref
             .read(uploadImageUseCaseProvider)
             .call(uid: uid, imageBytes: bytes),
       ),
@@ -128,11 +131,11 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
       await ref
           .read(postWriteViewModelProvider.notifier)
           .updatePost(
-        id: widget.post!.id,
-        content: content,
-        imageUrls: combinedImageUrls,
-        tags: _selectedTags,
-      );
+            id: widget.post!.id,
+            content: content,
+            imageUrls: combinedImageUrls,
+            tags: _selectedTags,
+          );
       if (!mounted) return;
       SnackbarUtil.showSnackBar(context, '수정되었습니다');
       Navigator.of(context).pop(true);
@@ -150,7 +153,14 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
     );
 
     if (!mounted) return;
-    await ref.read(feedNotifierProvider.notifier).refresh();
+    await ref.read(feedNotifierProvider(null).notifier).refresh();
+    await ref
+        .read(
+          feedNotifierProvider(
+            ref.read(userGlobalViewModelProvider)!.id,
+          ).notifier,
+        )
+        .refresh();
     if (!mounted) return;
 
     _contentController.clear();
@@ -290,16 +300,16 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
                               spacing: 8,
                               runSpacing: 4,
                               children:
-                              _selectedTags.map((tag) {
-                                return Chip(
-                                  label: Text(tag),
-                                  onDeleted: () {
-                                    setState(() {
-                                      _selectedTags.remove(tag);
-                                    });
-                                  },
-                                );
-                              }).toList(),
+                                  _selectedTags.map((tag) {
+                                    return Chip(
+                                      label: Text(tag),
+                                      onDeleted: () {
+                                        setState(() {
+                                          _selectedTags.remove(tag);
+                                        });
+                                      },
+                                    );
+                                  }).toList(),
                             ),
                           ),
                         const SizedBox(height: 16),

--- a/lib/presentation/pages/home/widgets/post_item.dart
+++ b/lib/presentation/pages/home/widgets/post_item.dart
@@ -39,7 +39,7 @@ class _PostItemState extends ConsumerState<PostItem> {
   @override
   Widget build(BuildContext context) {
     final List<ImageProvider> cachedImages = ref
-        .read(feedNotifierProvider.notifier)
+        .read(feedNotifierProvider(null).notifier)
         .getCachedImageProviders(widget.post);
 
     final DateTime now = ref.watch(timeAgoNotifierProvider);

--- a/lib/presentation/pages/home/widgets/post_menu_button.dart
+++ b/lib/presentation/pages/home/widgets/post_menu_button.dart
@@ -55,9 +55,6 @@ class PostMenuButton extends ConsumerWidget {
                     );
                     if (result == true) {
                       ref.invalidate(feedNotifierProvider);
-                      scaffoldMessenger.showSnackBar(
-                        const SnackBar(content: Text('게시글이 수정되었습니다')),
-                      );
                     }
                   },
                 ),

--- a/lib/presentation/pages/post/post_detail_page.dart
+++ b/lib/presentation/pages/post/post_detail_page.dart
@@ -13,15 +13,18 @@ class PostDetailPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     currentPostId = post.id;
-    return Scaffold(
-      appBar: AppBar(title: const Text('Post'), elevation: 0),
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            PostItem(post: post, displayComments: false),
-            const Divider(),
-            CommentSection(postId: post.id),
-          ],
+    return GestureDetector(
+      onTap: FocusScope.of(context).unfocus,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Post'), elevation: 0),
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              PostItem(post: post, displayComments: false),
+              const Divider(),
+              CommentSection(postId: post.id),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/profile_layout.dart
+++ b/lib/presentation/widgets/profile_layout.dart
@@ -3,6 +3,7 @@ import 'package:share_lingo/app/constants/app_colors.dart';
 import 'package:share_lingo/presentation/widgets/profile_images.dart';
 
 import '../../domain/entity/app_user.dart';
+import '../pages/home/tabs/feed/feed_tab.dart';
 
 class ProfileLayout extends StatelessWidget {
   final AppUser user;
@@ -101,7 +102,7 @@ class ProfileLayout extends StatelessWidget {
               languageLearningGoal: user.languageLearningGoal,
               hobbies: user.hobbies,
             ),
-            const PostListView(),
+            FeedTab(uid: user.id),
           ],
         ),
       ),
@@ -145,24 +146,6 @@ class _TabBarDelegate extends SliverPersistentHeaderDelegate {
   @override
   bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) =>
       false;
-}
-
-class PostListView extends StatelessWidget {
-  const PostListView({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.all(0),
-      itemCount: 10,
-      itemBuilder: (context, index) {
-        return ListTile(
-          title: Text('Post #$index'),
-          subtitle: Text('This is a sample post in the list.'),
-        );
-      },
-    );
-  }
 }
 
 class ProfileDetailsTab extends StatelessWidget {


### PR DESCRIPTION
프로필 페이지에서 사용자의 게시물 표시 (수정, 삭제, 신고 가능)
- Refactored FeedTab to accept and FeedNotifier to accept a nullable uid and load only the user's posts when called from the profile page (when uid is not null)