### PR TITLE
Feature/add poll button 투표기능 구현 

### DIFF
--- a/lib/core/providers/data_providers.dart
+++ b/lib/core/providers/data_providers.dart
@@ -10,6 +10,7 @@ import 'package:share_lingo/domain/usecase/fetch_lastest_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/fetch_older_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/update_post_usecase.dart';
 import 'package:share_lingo/domain/usecase/upload_image_usecase.dart';
+import 'package:share_lingo/domain/usecase/vote_post_usecase.dart';
 
 import '../../app/constants/app_constants.dart';
 import '../../data/data_source/firebase_auth_data_source.dart';
@@ -131,4 +132,8 @@ final imageStorageDataSourceProvider = Provider<ImageStorageDataSource>(
 
 final imageRepositoryProvider = Provider<ImageRepository>(
   (ref) => ImageRepositoryImpl(ref.read(imageStorageDataSourceProvider)),
+);
+
+final votePostUseCaseProvider = Provider(
+  (ref) => VotePostUseCase(ref.read(postRepositoryProvider)),
 );

--- a/lib/data/dto/post_dto.dart
+++ b/lib/data/dto/post_dto.dart
@@ -23,6 +23,13 @@ class PostDto {
   final int commentCount;
   final bool deleted;
 
+  // 투표 관련 필드 추가
+  final bool isPoll;
+  final String? pollQuestion;
+  final List<String>? pollOptions;
+  final Map<String, int>? pollVotes;
+  final Map<String, int>? userVotes;
+
   PostDto({
     required this.id,
     required this.uid,
@@ -44,6 +51,11 @@ class PostDto {
     required this.likeCount,
     required this.commentCount,
     required this.deleted,
+    this.isPoll = false,
+    this.pollQuestion,
+    this.pollOptions,
+    this.pollVotes,
+    this.userVotes,
   });
 
   factory PostDto.fromMap(String id, Map<String, dynamic> map) {
@@ -68,6 +80,22 @@ class PostDto {
       likeCount: map['likeCount'] ?? 0,
       commentCount: map['commentCount'] ?? 0,
       deleted: map['deleted'] ?? false,
+
+      // 투표 관련 매핑
+      isPoll: map['isPoll'] ?? false,
+      pollQuestion: map['pollQuestion'],
+      pollOptions:
+          map['pollOptions'] != null
+              ? List<String>.from(map['pollOptions'])
+              : null,
+      pollVotes:
+          map['pollVotes'] != null
+              ? Map<String, int>.from(map['pollVotes'])
+              : null,
+      userVotes:
+          map['userVotes'] != null
+              ? Map<String, int>.from(map['userVotes'])
+              : null,
     );
   }
 
@@ -92,6 +120,13 @@ class PostDto {
       'likeCount': likeCount,
       'commentCount': commentCount,
       'deleted': deleted,
+
+      // 투표 관련 필드도 포함
+      'isPoll': isPoll,
+      'pollQuestion': pollQuestion,
+      'pollOptions': pollOptions,
+      'pollVotes': pollVotes,
+      'userVotes': userVotes,
     };
   }
 
@@ -117,6 +152,13 @@ class PostDto {
       likeCount: likeCount,
       commentCount: commentCount,
       deleted: deleted,
+
+      // 투표 필드 매핑
+      isPoll: isPoll,
+      pollQuestion: pollQuestion,
+      pollOptions: pollOptions,
+      pollVotes: pollVotes,
+      userVotes: userVotes,
     );
   }
 
@@ -131,21 +173,30 @@ class PostDto {
       userDistrict: entity.userDistrict,
       userLocation: entity.userLocation,
       userBio: entity.userBio,
-      userBirthdate: entity.userBirthdate != null
-          ? Timestamp.fromDate(entity.userBirthdate!)
-          : null,
+      userBirthdate:
+          entity.userBirthdate != null
+              ? Timestamp.fromDate(entity.userBirthdate!)
+              : null,
       userHobbies: entity.userHobbies,
       userLanguageLearningGoal: entity.userLanguageLearningGoal,
       content: entity.content,
       imageUrl: entity.imageUrl,
       tags: entity.tags,
       createdAt: entity.createdAt,
-      updatedAt: entity.updatedAt != null
-          ? Timestamp.fromDate(entity.updatedAt!)
-          : null,
+      updatedAt:
+          entity.updatedAt != null
+              ? Timestamp.fromDate(entity.updatedAt!)
+              : null,
       likeCount: entity.likeCount,
       commentCount: entity.commentCount,
       deleted: entity.deleted,
+
+      //  투표 필드 매핑
+      isPoll: entity.isPoll,
+      pollQuestion: entity.pollQuestion,
+      pollOptions: entity.pollOptions,
+      pollVotes: entity.pollVotes,
+      userVotes: entity.userVotes,
     );
   }
 }

--- a/lib/data/repository/post_repository_impl.dart
+++ b/lib/data/repository/post_repository_impl.dart
@@ -118,4 +118,17 @@ class PostRepositoryImpl implements PostRepository {
   Stream<List<String>> getPostLikes(String postId) {
     return remoteDataSource.getPostLikes(postId);
   }
+
+  @override
+  Future<void> voteOnPost({
+    required String postId,
+    required String uid,
+    required int selectedIndex,
+  }) async {
+    await remoteDataSource.voteOnPost(
+      postId: postId,
+      uid: uid,
+      selectedIndex: selectedIndex,
+    );
+  }
 }

--- a/lib/domain/entity/post_entity.dart
+++ b/lib/domain/entity/post_entity.dart
@@ -22,6 +22,13 @@ class PostEntity {
   final int commentCount;
   final bool deleted;
 
+  //  투표 관련 필드 추가
+  final bool isPoll;
+  final String? pollQuestion;
+  final List<String>? pollOptions;
+  final Map<String, int>? pollVotes;
+  final Map<String, int>? userVotes;
+
   const PostEntity({
     required this.id,
     required this.uid,
@@ -43,6 +50,12 @@ class PostEntity {
     required this.likeCount,
     required this.commentCount,
     required this.deleted,
+    //  투표 관련 필드 추가
+    this.isPoll = false,
+    this.pollQuestion,
+    this.pollOptions,
+    this.pollVotes,
+    this.userVotes,
   });
 
   PostEntity copyWith({

--- a/lib/domain/repository/post_repository.dart
+++ b/lib/domain/repository/post_repository.dart
@@ -26,4 +26,9 @@ abstract class PostRepository {
   Future<bool> isPostLiked(String postId, String userId);
   Stream<int> getPostLikeCount(String postId);
   Stream<List<String>> getPostLikes(String postId);
+  Future<void> voteOnPost({
+    required String postId,
+    required String uid,
+    required int selectedIndex,
+  });
 }

--- a/lib/domain/usecase/vote_post_usecase.dart
+++ b/lib/domain/usecase/vote_post_usecase.dart
@@ -1,0 +1,19 @@
+import 'package:share_lingo/domain/repository/post_repository.dart';
+
+class VotePostUseCase {
+  final PostRepository repository;
+
+  VotePostUseCase(this.repository);
+
+  Future<void> call({
+    required String postId,
+    required String uid,
+    required int selectedIndex,
+  }) async {
+    await repository.voteOnPost(
+      postId: postId,
+      uid: uid,
+      selectedIndex: selectedIndex,
+    );
+  }
+}

--- a/lib/presentation/pages/home/tabs/feed/feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/core/utils/throttler_util.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_view_model.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_post_card.dart';
 import 'package:share_lingo/presentation/pages/home/widgets/post_item.dart';
 
 import '../../../../../app/constants/app_colors.dart';

--- a/lib/presentation/pages/home/tabs/feed/feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_tab.dart
@@ -97,17 +97,7 @@ class FeedTab extends StatelessWidget {
                         itemBuilder: (context, index) {
                           final post = posts[index];
 
-                          if (post.isPoll) {
-                            return Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                PollPostCard(post: post, now: DateTime.now()),
-                                PostItem(post: post, displayComments: true),
-                              ],
-                            );
-                          } else {
-                            return PostItem(post: post, displayComments: true);
-                          }
+                          return PostItem(post: post, displayComments: true);
                         },
                       ),
                     ),

--- a/lib/presentation/pages/home/tabs/feed/feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_tab.dart
@@ -97,7 +97,17 @@ class FeedTab extends StatelessWidget {
                         itemBuilder: (context, index) {
                           final post = posts[index];
 
-                          return PostItem(post: post, displayComments: true);
+                          if (post.isPoll) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                PollPostCard(post: post, now: DateTime.now()),
+                                PostItem(post: post, displayComments: true),
+                              ],
+                            );
+                          } else {
+                            return PostItem(post: post, displayComments: true);
+                          }
                         },
                       ),
                     ),

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -11,6 +11,7 @@ import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_view_model.da
 import 'package:share_lingo/presentation/pages/home/tabs/write/post_write_view_model.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/cancel_button.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/post_input_field.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/submit_button.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/tag_row_button.dart';
@@ -110,6 +111,8 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
   }
 
   Future<void> _submit() async {
+    final postNotifier = ref.read(postWriteViewModelProvider.notifier);
+
     if (_formKey.currentState?.validate() != true) return;
 
     final content = _contentController.text.trim();
@@ -138,13 +141,11 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
             tags: _selectedTags,
           );
       if (!mounted) return;
-      SnackbarUtil.showSnackBar(context, '수정되었습니다');
       Navigator.of(context).pop(true);
       return;
     }
 
     // 새 글 작성
-    final postNotifier = ref.read(postWriteViewModelProvider.notifier);
     await postNotifier.submitPost(
       ref: ref,
       uid: uid,
@@ -215,6 +216,10 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
                         PostInputField(controller: _contentController),
                         const SizedBox(height: 16),
 
+                        PollPreviewCard(
+                          question: widget.post?.pollQuestion ?? '',
+                          options: widget.post?.pollOptions ?? [],
+                        ),
                         if (_existingImageUrls.isNotEmpty)
                           SizedBox(
                             height: 100,

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -10,6 +10,7 @@ import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_view_model.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/post_write_view_model.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/cancel_button.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/post_input_field.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/submit_button.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/tag_row_button.dart';
@@ -292,6 +293,30 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
                             }
                           },
                           onPickImage: _pickImage,
+
+                          // 투표 다이얼로그 연결
+                          onAddPoll: () {
+                            showDialog(
+                              context: context,
+                              builder:
+                                  (context) => PollInputDialog(
+                                    onConfirm: ({
+                                      required question,
+                                      required option1,
+                                      required option2,
+                                    }) {
+                                      ref
+                                          .read(
+                                            postWriteViewModelProvider.notifier,
+                                          )
+                                          .setPollData(
+                                            question: question,
+                                            options: [option1, option2],
+                                          );
+                                    },
+                                  ),
+                            );
+                          },
                         ),
                         if (_selectedTags.isNotEmpty)
                           Padding(

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -9,6 +9,7 @@ import 'package:share_lingo/core/utils/snackbar_util.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_view_model.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/post_write_view_model.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/vote_state.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/cancel_button.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart';
@@ -139,6 +140,24 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
           .setPollData(question: uiPollQuestion!, options: uiPollOptions!);
     }
     if (widget.post != null) {
+      // 기존 투표 정보 무효화
+      if (uiPollQuestion != null && uiPollOptions != null) {
+        final postId = widget.post!.id;
+
+        // 상태 리셋
+        ref.read(voteStateProvider.notifier).reset(postId);
+
+        // 빈 값으로 다시 설정 (선택도 초기화)
+        ref
+            .read(voteStateProvider.notifier)
+            .set(
+              postId,
+              VoteState(
+                pollVotes: {}, // 새로운 투표니까 초기화
+                selectedIndex: null,
+              ),
+            );
+      }
       // 수정 모드
       await ref
           .read(postWriteViewModelProvider.notifier)

--- a/lib/presentation/pages/home/tabs/write/post_write_view_model.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_view_model.dart
@@ -104,6 +104,8 @@ class PostWriteViewModel extends StateNotifier<AsyncValue<void>> {
           'isPoll': true,
           if (_pollQuestion != null) 'pollQuestion': _pollQuestion!,
           if (_pollOptions != null) 'pollOptions': _pollOptions!,
+          'pollVotes': <String, int>{},
+          'userVotes': <String, int>{},
         });
       } else {
         updateData.addAll({

--- a/lib/presentation/pages/home/tabs/write/vote_state.dart
+++ b/lib/presentation/pages/home/tabs/write/vote_state.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class VoteState {
+  final Map<String, int> pollVotes; // index → count
+  final int? selectedIndex;
+
+  VoteState({required this.pollVotes, this.selectedIndex});
+
+  VoteState copyWith({Map<String, int>? pollVotes, int? selectedIndex}) {
+    return VoteState(
+      pollVotes: pollVotes ?? this.pollVotes,
+      selectedIndex: selectedIndex ?? this.selectedIndex,
+    );
+  }
+}
+
+class VoteStateNotifier extends StateNotifier<Map<String, VoteState>> {
+  VoteStateNotifier() : super({});
+
+  void set(String postId, VoteState stateForPost) {
+    state = {...state, postId: stateForPost};
+  }
+
+  VoteState? get(String postId) => state[postId];
+}
+
+final voteStateProvider =
+    StateNotifierProvider<VoteStateNotifier, Map<String, VoteState>>(
+      (ref) => VoteStateNotifier(),
+    );

--- a/lib/presentation/pages/home/tabs/write/vote_state.dart
+++ b/lib/presentation/pages/home/tabs/write/vote_state.dart
@@ -22,6 +22,9 @@ class VoteStateNotifier extends StateNotifier<Map<String, VoteState>> {
   }
 
   VoteState? get(String postId) => state[postId];
+  void reset(String postId) {
+    state = {...state, postId: VoteState(pollVotes: {}, selectedIndex: null)};
+  }
 }
 
 final voteStateProvider =

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart
@@ -27,33 +27,56 @@ class _PollInputDialogState extends State<PollInputDialog> {
     super.dispose();
   }
 
+  InputDecoration _buildInputDecoration(String label) {
+    return InputDecoration(
+      labelText: label,
+      filled: true,
+      fillColor: Colors.grey.shade100,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: Colors.grey),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: Colors.deepPurple),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('투표 만들기'),
+      backgroundColor: Colors.white,
+      title: const Text(
+        '투표',
+        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           TextField(
             controller: _questionController,
-            decoration: const InputDecoration(labelText: '질문'),
+            decoration: _buildInputDecoration('질문을 입력하세요'),
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 14),
           TextField(
             controller: _option1Controller,
-            decoration: const InputDecoration(labelText: '선택지 1'),
+            decoration: _buildInputDecoration('선택지 1'),
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 14),
           TextField(
             controller: _option2Controller,
-            decoration: const InputDecoration(labelText: '선택지 2'),
+            decoration: _buildInputDecoration('선택지 2'),
           ),
         ],
       ),
+      actionsPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(), // 닫기
-          child: const Text('취소'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('취소', style: TextStyle(color: Colors.grey)),
         ),
         ElevatedButton(
           onPressed: () {
@@ -63,10 +86,17 @@ class _PollInputDialogState extends State<PollInputDialog> {
 
             if (q.isNotEmpty && o1.isNotEmpty && o2.isNotEmpty) {
               widget.onConfirm(question: q, option1: o1, option2: o2);
-              Navigator.of(context).pop(); // 다이얼로그 닫기
+              Navigator.of(context).pop();
             }
           },
-          child: const Text('확인'),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.deepPurple,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          ),
+          child: const Text('확인', style: TextStyle(color: Colors.white)),
         ),
       ],
     );

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class PollInputDialog extends StatefulWidget {
+  final void Function({
+    required String question,
+    required String option1,
+    required String option2,
+  })
+  onConfirm;
+
+  const PollInputDialog({super.key, required this.onConfirm});
+
+  @override
+  State<PollInputDialog> createState() => _PollInputDialogState();
+}
+
+class _PollInputDialogState extends State<PollInputDialog> {
+  final TextEditingController _questionController = TextEditingController();
+  final TextEditingController _option1Controller = TextEditingController();
+  final TextEditingController _option2Controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _questionController.dispose();
+    _option1Controller.dispose();
+    _option2Controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('투표 만들기'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _questionController,
+            decoration: const InputDecoration(labelText: '질문'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _option1Controller,
+            decoration: const InputDecoration(labelText: '선택지 1'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _option2Controller,
+            decoration: const InputDecoration(labelText: '선택지 2'),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(), // 닫기
+          child: const Text('취소'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            final q = _questionController.text.trim();
+            final o1 = _option1Controller.text.trim();
+            final o2 = _option2Controller.text.trim();
+
+            if (q.isNotEmpty && o1.isNotEmpty && o2.isNotEmpty) {
+              widget.onConfirm(question: q, option1: o1, option2: o2);
+              Navigator.of(context).pop(); // 다이얼로그 닫기
+            }
+          },
+          child: const Text('확인'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:share_lingo/core/providers/data_providers.dart';
+import 'package:share_lingo/domain/entity/post_entity.dart';
+import 'package:share_lingo/core/utils/format_time_ago.dart';
+import 'package:share_lingo/core/utils/general_utils.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/vote_state.dart';
+import 'package:share_lingo/presentation/widgets/app_cached_image.dart';
+
+class PollPostCard extends ConsumerStatefulWidget {
+  final PostEntity post;
+  final DateTime now;
+  final bool showDeleteButton;
+  final VoidCallback? onDelete;
+
+  const PollPostCard({
+    super.key,
+    required this.post,
+    required this.now,
+    this.showDeleteButton = false,
+    this.onDelete,
+  });
+
+  @override
+  ConsumerState<PollPostCard> createState() => _PollPostCardState();
+}
+
+class _PollPostCardState extends ConsumerState<PollPostCard> {
+  @override
+  Widget build(BuildContext context) {
+    final post = widget.post;
+    final voteState = ref.watch(voteStateProvider)[post.id];
+    final selectedIndex = voteState?.selectedIndex;
+    final pollVotes = voteState?.pollVotes ?? {};
+    final options = post.pollOptions ?? [];
+    final totalVotes = pollVotes.values.fold<int>(0, (sum, v) => sum + v);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 12),
+          _topBar(),
+          const SizedBox(height: 10),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  post.pollQuestion ?? '',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              if (widget.showDeleteButton && widget.onDelete != null)
+                GestureDetector(
+                  onTap: () async {
+                    final confirm = await showDialog<bool>(
+                      context: context,
+                      builder:
+                          (context) => AlertDialog(
+                            title: const Text('투표 삭제'),
+                            content: const Text('정말 투표를 삭제하시겠습니까?'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(context, false),
+                                child: const Text('취소'),
+                              ),
+                              ElevatedButton(
+                                onPressed: () => Navigator.pop(context, true),
+                                child: const Text('삭제'),
+                              ),
+                            ],
+                          ),
+                    );
+
+                    if (confirm == true && mounted) {
+                      widget.onDelete!();
+                    }
+                  },
+                  child: const Icon(Icons.close, size: 20, color: Colors.grey),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          for (int i = 0; i < options.length; i++)
+            _buildOption(
+              i,
+              options[i],
+              pollVotes['$i'] ?? 0,
+              totalVotes,
+              selectedIndex,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _topBar() {
+    final post = widget.post;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ClipOval(
+          child: AppCachedImage(
+            imageUrl: post.userProfileImage,
+            width: 50,
+            height: 50,
+            fit: BoxFit.cover,
+          ),
+        ),
+        const SizedBox(width: 10),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  post.userName,
+                  style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  FormatTimeAgo.formatTimeAgo(
+                    now: widget.now,
+                    createdAt: post.createdAt,
+                  ),
+                  style: const TextStyle(
+                    fontSize: 15,
+                    color: Colors.black54,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Text(
+                  GeneralUtils.getLanguageCodeByName(
+                    post.userNativeLanguage,
+                  )!.toUpperCase(),
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black54,
+                  ),
+                ),
+                const SizedBox(
+                  width: 30,
+                  child: Icon(
+                    Icons.sync_alt_outlined,
+                    size: 16,
+                    color: Colors.black26,
+                  ),
+                ),
+                Text(
+                  GeneralUtils.getLanguageCodeByName(
+                    post.userTargetLanguage,
+                  )!.toUpperCase(),
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black54,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOption(
+    int index,
+    String label,
+    int count,
+    int total,
+    int? selectedIndex,
+  ) {
+    final alreadyVoted = selectedIndex != null;
+    final percent = total == 0 ? 0 : ((count / total) * 100).round();
+
+    return InkWell(
+      onTap:
+          alreadyVoted
+              ? null
+              : () async {
+                final uid = FirebaseAuth.instance.currentUser?.uid;
+                if (uid == null) return;
+
+                try {
+                  await ref
+                      .read(votePostUseCaseProvider)
+                      .call(
+                        postId: widget.post.id,
+                        uid: uid,
+                        selectedIndex: index,
+                      );
+
+                  final updatedVotes = Map<String, int>.from(
+                    ref.read(voteStateProvider)[widget.post.id]?.pollVotes ??
+                        {},
+                  );
+                  updatedVotes['$index'] = (updatedVotes['$index'] ?? 0) + 1;
+
+                  ref
+                      .read(voteStateProvider.notifier)
+                      .set(
+                        widget.post.id,
+                        VoteState(
+                          pollVotes: updatedVotes,
+                          selectedIndex: index,
+                        ),
+                      );
+                } catch (e) {
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('이미 투표하셨습니다.')),
+                    );
+                  }
+                }
+              },
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 8),
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+        decoration: BoxDecoration(
+          color: alreadyVoted ? Colors.grey.shade200 : Colors.blue.shade50,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selectedIndex == index ? Colors.blue : Colors.grey.shade300,
+            width: 1,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(label, style: const TextStyle(fontSize: 15)),
+            if (alreadyVoted)
+              Text(
+                '$percent%',
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 14,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
@@ -42,8 +42,7 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const SizedBox(height: 12),
-          _topBar(),
-          const SizedBox(height: 10),
+
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -100,84 +99,6 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
     );
   }
 
-  Widget _topBar() {
-    final post = widget.post;
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ClipOval(
-          child: AppCachedImage(
-            imageUrl: post.userProfileImage,
-            width: 50,
-            height: 50,
-            fit: BoxFit.cover,
-          ),
-        ),
-        const SizedBox(width: 10),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Text(
-                  post.userName,
-                  style: const TextStyle(
-                    fontSize: 17,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  FormatTimeAgo.formatTimeAgo(
-                    now: widget.now,
-                    createdAt: post.createdAt,
-                  ),
-                  style: const TextStyle(
-                    fontSize: 15,
-                    color: Colors.black54,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
-            ),
-            Row(
-              children: [
-                Text(
-                  GeneralUtils.getLanguageCodeByName(
-                    post.userNativeLanguage,
-                  )!.toUpperCase(),
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black54,
-                  ),
-                ),
-                const SizedBox(
-                  width: 30,
-                  child: Icon(
-                    Icons.sync_alt_outlined,
-                    size: 16,
-                    color: Colors.black26,
-                  ),
-                ),
-                Text(
-                  GeneralUtils.getLanguageCodeByName(
-                    post.userTargetLanguage,
-                  )!.toUpperCase(),
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black54,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
   Widget _buildOption(
     int index,
     String label,
@@ -186,9 +107,10 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
     int? selectedIndex,
   ) {
     final alreadyVoted = selectedIndex != null;
+    final isSelected = selectedIndex == index;
     final percent = total == 0 ? 0 : ((count / total) * 100).round();
 
-    return InkWell(
+    return GestureDetector(
       onTap:
           alreadyVoted
               ? null
@@ -228,27 +150,43 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
                   }
                 }
               },
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 8),
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        margin: const EdgeInsets.only(bottom: 10),
+        padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
         decoration: BoxDecoration(
-          color: alreadyVoted ? Colors.grey.shade200 : Colors.blue.shade50,
-          borderRadius: BorderRadius.circular(8),
+          color: isSelected ? Colors.blueAccent : Colors.grey.shade50,
+          borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: selectedIndex == index ? Colors.blue : Colors.grey.shade300,
-            width: 1,
+            color: isSelected ? Colors.blueAccent : Colors.grey.shade300,
+            width: 1.2,
           ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.grey.shade200,
+              blurRadius: 6,
+              offset: const Offset(0, 2),
+            ),
+          ],
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(label, style: const TextStyle(fontSize: 15)),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w500,
+                color: isSelected ? Colors.white : Colors.black87,
+              ),
+            ),
             if (alreadyVoted)
               Text(
                 '$percent%',
-                style: const TextStyle(
+                style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
+                  color: isSelected ? Colors.white : Colors.black54,
                 ),
               ),
           ],

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
@@ -3,10 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:share_lingo/core/providers/data_providers.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
-import 'package:share_lingo/core/utils/format_time_ago.dart';
-import 'package:share_lingo/core/utils/general_utils.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/vote_state.dart';
-import 'package:share_lingo/presentation/widgets/app_cached_image.dart';
 
 class PollPostCard extends ConsumerStatefulWidget {
   final PostEntity post;

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_post_card.dart
@@ -93,6 +93,7 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
               pollVotes['$i'] ?? 0,
               totalVotes,
               selectedIndex,
+              voteState,
             ),
         ],
       ),
@@ -105,8 +106,10 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
     int count,
     int total,
     int? selectedIndex,
+    VoteState? voteState,
   ) {
-    final alreadyVoted = selectedIndex != null;
+    final alreadyVoted = voteState != null && voteState.selectedIndex != null;
+
     final isSelected = selectedIndex == index;
     final percent = total == 0 ? 0 : ((count / total) * 100).round();
 
@@ -143,7 +146,7 @@ class _PollPostCardState extends ConsumerState<PollPostCard> {
                         ),
                       );
                 } catch (e) {
-                  if (mounted) {
+                  if (mounted && voteState?.selectedIndex != null) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('이미 투표하셨습니다.')),
                     );

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart
@@ -3,46 +3,95 @@ import 'package:flutter/material.dart';
 class PollPreviewCard extends StatelessWidget {
   final String question;
   final List<String> options;
+  final VoidCallback? onDelete;
 
   const PollPreviewCard({
     super.key,
     required this.question,
     required this.options,
+    this.onDelete,
   });
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
       decoration: BoxDecoration(
-        color: Colors.indigo.shade50,
-        border: Border.all(color: Colors.indigo.shade200),
-        borderRadius: BorderRadius.circular(12),
+        color: Colors.white,
+        border: Border.all(color: Colors.grey.shade300),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black12,
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
             '📊 투표 미리보기',
-            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-          ),
-          const SizedBox(height: 8),
-          Text(question, style: const TextStyle(fontSize: 15)),
-          const SizedBox(height: 10),
-          ...options.map(
-            (option) => Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: Row(
-                children: [
-                  const Icon(Icons.radio_button_unchecked, size: 16),
-                  const SizedBox(width: 8),
-                  Expanded(child: Text(option)),
-                ],
-              ),
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: Colors.black87,
             ),
           ),
+          const SizedBox(height: 12),
+          Text(
+            question,
+            style: const TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.bold,
+              color: Colors.black,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...options.map((option) => _buildOption(option)).toList(),
+          const SizedBox(height: 12),
+          if (onDelete != null)
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: onDelete,
+                icon: const Icon(Icons.delete_outline, color: Colors.redAccent),
+                label: const Text(
+                  '삭제',
+                  style: TextStyle(color: Colors.redAccent),
+                ),
+              ),
+            ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildOption(String label) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade300, width: 1.2),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.shade100,
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w500,
+          color: Colors.black87,
+        ),
       ),
     );
   }

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class PollPreviewCard extends StatelessWidget {
+  final String question;
+  final List<String> options;
+
+  const PollPreviewCard({
+    super.key,
+    required this.question,
+    required this.options,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.indigo.shade50,
+        border: Border.all(color: Colors.indigo.shade200),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '📊 투표 미리보기',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          ),
+          const SizedBox(height: 8),
+          Text(question, style: const TextStyle(fontSize: 15)),
+          const SizedBox(height: 10),
+          ...options.map(
+            (option) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                children: [
+                  const Icon(Icons.radio_button_unchecked, size: 16),
+                  const SizedBox(width: 8),
+                  Expanded(child: Text(option)),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_preview_card.dart
@@ -50,7 +50,7 @@ class PollPreviewCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
-          ...options.map((option) => _buildOption(option)).toList(),
+          ...[for (final option in options) _buildOption(option)],
           const SizedBox(height: 12),
           if (onDelete != null)
             Align(

--- a/lib/presentation/pages/home/tabs/write/widgets/tag_row_button.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/tag_row_button.dart
@@ -6,11 +6,15 @@ import '../../../../../../app/constants/app_colors.dart';
 class TagRowButton extends StatelessWidget {
   final void Function(String tag) onTagSelected;
   final VoidCallback onPickImage;
+  final VoidCallback onAddPoll;
+
+  ///투표 버튼 콜백
 
   const TagRowButton({
     super.key,
     required this.onTagSelected,
     required this.onPickImage,
+    required this.onAddPoll,
   });
 
   @override
@@ -52,7 +56,19 @@ class TagRowButton extends StatelessWidget {
               materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
             ),
           ),
-
+          GestureDetector(
+            onTap: onAddPoll,
+            child: Container(
+              width: 48,
+              height: 48,
+              decoration: const BoxDecoration(
+                color: Colors.deepPurple,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.poll, color: Colors.white),
+            ),
+          ),
+          const SizedBox(width: 8), // 왼쪽 여백
           // 오른쪽: 카메라 버튼
           GestureDetector(
             onTap: () {

--- a/lib/presentation/pages/home/widgets/post_item.dart
+++ b/lib/presentation/pages/home/widgets/post_item.dart
@@ -1,9 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_image_viewer/easy_image_viewer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/app/constants/app_colors.dart';
 import 'package:share_lingo/core/utils/format_time_ago.dart';
 import 'package:share_lingo/core/utils/general_utils.dart';
+import 'package:share_lingo/data/dto/post_dto.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_view_model.dart';
 import 'package:share_lingo/presentation/pages/home/widgets/expandable_text.dart';
@@ -45,12 +47,24 @@ class _PostItemState extends ConsumerState<PostItem> {
     final DateTime now = ref.watch(timeAgoNotifierProvider);
     return InkWell(
       highlightColor: AppColors.lightGrey,
-      onTap: () {
+      onTap: () async {
         if (PostDetailPage.currentPostId != widget.post.id) {
-          Navigator.push(
+          // ✅ Firestore에서 최신 데이터 가져오기
+          final doc =
+              await FirebaseFirestore.instance
+                  .collection('posts')
+                  .doc(widget.post.id)
+                  .get();
+
+          if (!doc.exists) return; // 예외 처리
+
+          final dto = PostDto.fromMap(doc.id, doc.data()!);
+          final freshPost = dto.toEntity();
+
+          await Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (context) => PostDetailPage(post: widget.post),
+              builder: (context) => PostDetailPage(post: freshPost),
             ),
           ).then((value) {
             PostDetailPage.currentPostId = null;

--- a/lib/presentation/pages/post/post_detail_page.dart
+++ b/lib/presentation/pages/post/post_detail_page.dart
@@ -12,10 +12,18 @@ class PostDetailPage extends ConsumerStatefulWidget {
   const PostDetailPage({super.key, required this.post});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    currentPostId = post.id;
+  ConsumerState<PostDetailPage> createState() => _PostDetailPageState();
+}
+
+class _PostDetailPageState extends ConsumerState<PostDetailPage> {
+  @override
+  Widget build(BuildContext context) {
+    final post = widget.post;
+    final ref = this.ref;
+    PostDetailPage.currentPostId = post.id;
+
     return GestureDetector(
-      onTap: FocusScope.of(context).unfocus,
+      onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
         appBar: AppBar(title: const Text('Post'), elevation: 0),
         body: SingleChildScrollView(

--- a/lib/presentation/pages/post/post_detail_page.dart
+++ b/lib/presentation/pages/post/post_detail_page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_post_card.dart';
 import 'package:share_lingo/presentation/pages/home/widgets/post_item.dart';
 import 'package:share_lingo/presentation/widgets/comment_section.dart';
 
-class PostDetailPage extends ConsumerWidget {
+class PostDetailPage extends ConsumerStatefulWidget {
   final PostEntity post;
   static String? currentPostId;
 
@@ -21,6 +22,11 @@ class PostDetailPage extends ConsumerWidget {
           child: Column(
             children: [
               PostItem(post: post, displayComments: false),
+              if (post.isPoll)
+                Padding(
+                  padding: const EdgeInsets.only(top: 16.0),
+                  child: PollPostCard(post: post, now: DateTime.now()),
+                ),
               const Divider(),
               CommentSection(postId: post.id),
             ],

--- a/lib/presentation/pages/post/post_detail_page.dart
+++ b/lib/presentation/pages/post/post_detail_page.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
@@ -27,11 +28,16 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
 
     // 투표 상태 초기화
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      final selected = _post.userVotes?[uid]; //사용자 투표 선택 불러오기
       ref
           .read(voteStateProvider.notifier)
           .set(
             _post.id,
-            VoteState(pollVotes: _post.pollVotes ?? {}, selectedIndex: null),
+            VoteState(
+              pollVotes: _post.pollVotes ?? {},
+              selectedIndex: selected,
+            ),
           );
     });
   }

--- a/lib/presentation/pages/post/post_detail_page.dart
+++ b/lib/presentation/pages/post/post_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/write/vote_state.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/widgets/poll_post_card.dart';
 import 'package:share_lingo/presentation/pages/home/widgets/post_item.dart';
 import 'package:share_lingo/presentation/widgets/comment_section.dart';
@@ -16,12 +17,27 @@ class PostDetailPage extends ConsumerStatefulWidget {
 }
 
 class _PostDetailPageState extends ConsumerState<PostDetailPage> {
+  late PostEntity _post;
+
+  @override
+  void initState() {
+    super.initState();
+    _post = widget.post;
+    PostDetailPage.currentPostId = _post.id;
+
+    // 투표 상태 초기화
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref
+          .read(voteStateProvider.notifier)
+          .set(
+            _post.id,
+            VoteState(pollVotes: _post.pollVotes ?? {}, selectedIndex: null),
+          );
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    final post = widget.post;
-    final ref = this.ref;
-    PostDetailPage.currentPostId = post.id;
-
     return GestureDetector(
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
@@ -29,14 +45,14 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
         body: SingleChildScrollView(
           child: Column(
             children: [
-              PostItem(post: post, displayComments: false),
-              if (post.isPoll)
+              PostItem(post: _post, displayComments: false),
+              if (_post.isPoll)
                 Padding(
                   padding: const EdgeInsets.only(top: 16.0),
-                  child: PollPostCard(post: post, now: DateTime.now()),
+                  child: PollPostCard(post: _post, now: DateTime.now()),
                 ),
               const Divider(),
-              CommentSection(postId: post.id),
+              CommentSection(postId: _post.id),
             ],
           ),
         ),


### PR DESCRIPTION
✅ 투표 기능 추가
PollPostCard 위젯: 투표 보기 및 선택 UI 구현

VoteStateNotifier: 투표 상태 관리 (선택 항목 및 투표 수)

Firestore 저장: pollVotes, userVotes

✅ 글쓰기 페이지에 투표 추가 기능
PollInputDialog, PollPreviewCard 구성

setPollData() 통해 ViewModel에 투표 정보 저장

✅ 투표 수정 및 삭제
수정 시 voteStateProvider.reset(postId) 호출로 상태 초기화

삭제 시 Firestore에서 관련 필드 제거 (pollQuestion, pollOptions, pollVotes, userVotes)

✅ 상세페이지 상태 갱신
수정 완료 후 Navigator.pop(true) 처리

PostDetailPage에서 Firestore 재조회 및 VoteState 초기화 반영

✅ UX 개선
중복 투표 시 Snackbar 안내

수정된 투표는 선택 초기화 후 다시 투표 가능

피드탭 → 상세 진입 시 항상 최신 데이터 fetch