### PR TITLE
피드 탭 필터 및 추천/동급생/근처 탭 추가

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -101,17 +101,17 @@ exports.updateUpdatedAtOnCommentChange = functions.firestore
 // 4. Comment Count Management
 /////////////////////////
 
-//exports.updateCommentCount = functions.firestore
-//  .document("posts/{postId}/comments/{commentId}")
-//  .onWrite(async (change, context) => {
-//    const postId = context.params.postId;
-//    const postRef = db.collection("posts").doc(postId);
-//
-//    const commentsSnapshot = await postRef.collection("comments").get();
-//    const commentCount = commentsSnapshot.size;
-//
-//    return postRef.update({ commentCount });
-//  });
+exports.updateCommentCount = functions.firestore
+  .document("posts/{postId}/comments/{commentId}")
+  .onWrite(async (change, context) => {
+    const postId = context.params.postId;
+    const postRef = db.collection("posts").doc(postId);
+
+    const commentsSnapshot = await postRef.collection("comments").get();
+    const commentCount = commentsSnapshot.size;
+
+    return postRef.update({ commentCount });
+  });
 
 /////////////////////////
 // 5. Like Count Management

--- a/lib/core/utils/general_utils.dart
+++ b/lib/core/utils/general_utils.dart
@@ -14,7 +14,7 @@ class GeneralUtils {
       locale: const Locale('ko'),
       initialDate: initialDate ?? now.subtract(const Duration(days: 365 * 20)),
       firstDate: DateTime(1900),
-      lastDate: now,
+      lastDate: DateTime(now.year - 18, now.month, now.day),
       builder: (context, child) {
         return Theme(
           data: Theme.of(context).copyWith(

--- a/lib/data/data_source/post_data_source.dart
+++ b/lib/data/data_source/post_data_source.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-abstract interface class PostDataSource {}
-
-class PostDataSourceImpl implements PostDataSource {}
-
-final postDataSourceProvider = Provider<PostDataSource>((ref) {
-  return PostDataSourceImpl();
-});

--- a/lib/data/data_source/post_remote_data_source.dart
+++ b/lib/data/data_source/post_remote_data_source.dart
@@ -83,7 +83,11 @@ class PostRemoteDataSource {
     return reversedList.reversed.toList();
   }
 
-  Query<Map<String, dynamic>> _applyFilter(Query<Map<String, dynamic>> base, String? filter, AppUser? user) {
+  Query<Map<String, dynamic>> _applyFilter(
+    Query<Map<String, dynamic>> base,
+    String? filter,
+    AppUser? user,
+  ) {
     if (filter == 'recommended' && user != null) {
       return base
           .where('userNativeLanguage', isEqualTo: user.targetLanguage)
@@ -101,14 +105,20 @@ class PostRemoteDataSource {
     return base;
   }
 
-  Future<List<PostDto>> fetchCurrentPosts(PostEntity firstPost) async {
-    final snapshot =
-        await firestore
-            .collection('posts')
-            .orderBy('createdAt', descending: true)
-            .startAfter([firstPost.createdAt])
-            .limit(50)
-            .get();
+  Future<List<PostDto>> fetchCurrentPosts(
+    PostEntity firstPost, {
+    String? filter,
+    AppUser? user,
+  }) async {
+    Query<Map<String, dynamic>> base = firestore
+        .collection('posts')
+        .orderBy('createdAt', descending: true)
+        .startAfter([firstPost.createdAt])
+        .limit(50);
+
+    final query = _applyFilter(base, filter, user);
+    final snapshot = await query.get();
+
     return snapshot.docs
         .map((doc) => PostDto.fromMap(doc.id, doc.data()))
         .toList();

--- a/lib/data/data_source/post_remote_data_source.dart
+++ b/lib/data/data_source/post_remote_data_source.dart
@@ -96,10 +96,13 @@ class PostRemoteDataSource {
       return base
           .where('userNativeLanguage', isEqualTo: user.nativeLanguage)
           .where('userTargetLanguage', isEqualTo: user.targetLanguage);
-    } else if (filter == 'nearby' &&
-        user != null &&
-        user.district != null &&
-        user.district != '') {
+    } else if (filter == 'nearby') {
+      if (user == null || user.district == null || user.district!.isEmpty) {
+        return base.where(
+          'userDistrict',
+          isEqualTo: '__none__',
+        ); // unlikely to match anything
+      }
       return base.where('userDistrict', isEqualTo: user.district);
     }
     return base;

--- a/lib/data/repository/post_repository_impl.dart
+++ b/lib/data/repository/post_repository_impl.dart
@@ -23,28 +23,56 @@ class PostRepositoryImpl implements PostRepository {
   }
 
   @override
-  Future<List<PostEntity>> fetchInitialPosts({String? filter, AppUser? user}) async {
-    final dtoList = await remoteDataSource.fetchInitialPosts(filter: filter, user: user);
+  Future<List<PostEntity>> fetchInitialPosts({
+    String? filter,
+    AppUser? user,
+  }) async {
+    final dtoList = await remoteDataSource.fetchInitialPosts(
+      filter: filter,
+      user: user,
+    );
     return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<List<PostEntity>> fetchOlderPosts(PostEntity lastPost, {String? filter, AppUser? user}) async {
-    final dtoList = await remoteDataSource.fetchOlderPosts(lastPost, filter: filter, user: user);
+  Future<List<PostEntity>> fetchOlderPosts(
+    PostEntity lastPost, {
+    String? filter,
+    AppUser? user,
+  }) async {
+    final dtoList = await remoteDataSource.fetchOlderPosts(
+      lastPost,
+      filter: filter,
+      user: user,
+    );
     return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<List<PostEntity>> fetchLatestPosts(PostEntity firstPost, {String? filter, AppUser? user}) async {
-    final dtoList = await remoteDataSource.fetchLatestPosts(firstPost, filter: filter, user: user);
+  Future<List<PostEntity>> fetchLatestPosts(
+    PostEntity firstPost, {
+    String? filter,
+    AppUser? user,
+  }) async {
+    final dtoList = await remoteDataSource.fetchLatestPosts(
+      firstPost,
+      filter: filter,
+      user: user,
+    );
     return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
   Future<List<PostEntity>> fetchCurrentUpdatedPosts(
-    PostEntity firstPost,
-  ) async {
-    final dtoList = await remoteDataSource.fetchCurrentPosts(firstPost)
+      PostEntity firstPost, {
+        String? filter,
+        AppUser? user,
+      }) async {
+    final dtoList = await remoteDataSource.fetchCurrentPosts(
+      firstPost,
+      filter: filter,
+      user: user,
+    )
       ..where((p) => p.updatedAt != null).toList();
     return dtoList.map((dto) => dto.toEntity()).toList();
   }

--- a/lib/data/repository/post_repository_impl.dart
+++ b/lib/data/repository/post_repository_impl.dart
@@ -1,15 +1,6 @@
-/*
-import '../../domain/repository/post_repository.dart';
-import '../data_source/post_data_source.dart';
-
-class PostRepositoryImpl implements PostRepository {
-  final PostDataSource _dataSource;
-
-  PostRepositoryImpl(this._dataSource);
-}
-*/
 import 'dart:typed_data';
 
+import '../../domain/entity/app_user.dart';
 import '../../domain/entity/post_entity.dart';
 import '../../domain/repository/post_repository.dart';
 import '../data_source/post_remote_data_source.dart';
@@ -32,20 +23,20 @@ class PostRepositoryImpl implements PostRepository {
   }
 
   @override
-  Future<List<PostEntity>> fetchInitialPosts() async {
-    final dtoList = await remoteDataSource.fetchInitialPosts();
+  Future<List<PostEntity>> fetchInitialPosts({String? filter, AppUser? user}) async {
+    final dtoList = await remoteDataSource.fetchInitialPosts(filter: filter, user: user);
     return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<List<PostEntity>> fetchOlderPosts(PostEntity lastPost) async {
-    final dtoList = await remoteDataSource.fetchOlderPosts(lastPost);
+  Future<List<PostEntity>> fetchOlderPosts(PostEntity lastPost, {String? filter, AppUser? user}) async {
+    final dtoList = await remoteDataSource.fetchOlderPosts(lastPost, filter: filter, user: user);
     return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<List<PostEntity>> fetchLatestPosts(PostEntity firstPost) async {
-    final dtoList = await remoteDataSource.fetchLatestPosts(firstPost);
+  Future<List<PostEntity>> fetchLatestPosts(PostEntity firstPost, {String? filter, AppUser? user}) async {
+    final dtoList = await remoteDataSource.fetchLatestPosts(firstPost, filter: filter, user: user);
     return dtoList.map((dto) => dto.toEntity()).toList();
   }
 

--- a/lib/domain/repository/post_repository.dart
+++ b/lib/domain/repository/post_repository.dart
@@ -1,13 +1,14 @@
 import 'dart:typed_data';
 
+import '../entity/app_user.dart';
 import '../entity/post_entity.dart';
 
 abstract class PostRepository {
   Future<void> createPost(PostEntity post);
   Future<String> uploadImage(String uid, Uint8List imageBytes);
-  Future<List<PostEntity>> fetchInitialPosts();
-  Future<List<PostEntity>> fetchOlderPosts(PostEntity lastPost);
-  Future<List<PostEntity>> fetchLatestPosts(PostEntity firstPost);
+  Future<List<PostEntity>> fetchInitialPosts({String? filter, AppUser? user});
+  Future<List<PostEntity>> fetchOlderPosts(PostEntity lastPost, {String? filter, AppUser? user});
+  Future<List<PostEntity>> fetchLatestPosts(PostEntity firstPost, {String? filter, AppUser? user});
   Future<void> updatePost({
     required String id,
     required String content,

--- a/lib/domain/repository/post_repository.dart
+++ b/lib/domain/repository/post_repository.dart
@@ -9,7 +9,7 @@ abstract class PostRepository {
   Future<List<PostEntity>> fetchInitialPosts({String? filter, AppUser? user});
   Future<List<PostEntity>> fetchOlderPosts(PostEntity lastPost, {String? filter, AppUser? user});
   Future<List<PostEntity>> fetchLatestPosts(PostEntity firstPost, {String? filter, AppUser? user});
-  Future<List<PostEntity>> fetchCurrentUpdatedPosts(PostEntity firstPost);
+  Future<List<PostEntity>> fetchCurrentUpdatedPosts(PostEntity firstPost, {String? filter, AppUser? user});
   Future<void> updatePost({
     required String id,
     required String content,

--- a/lib/domain/usecase/fetch_current_updated_posts_usecase.dart
+++ b/lib/domain/usecase/fetch_current_updated_posts_usecase.dart
@@ -1,12 +1,22 @@
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/domain/repository/post_repository.dart';
 
+import '../entity/app_user.dart';
+
 class FetchCurrentUpdatedPostsUsecase {
   final PostRepository repository;
 
   FetchCurrentUpdatedPostsUsecase(this.repository);
 
-  Future<List<PostEntity>> execute(PostEntity firstPost) async {
-    return await repository.fetchCurrentUpdatedPosts(firstPost);
+  Future<List<PostEntity>> execute(
+    PostEntity firstPost, {
+    String? filter,
+    AppUser? user,
+  }) async {
+    return await repository.fetchCurrentUpdatedPosts(
+      firstPost,
+      filter: filter,
+      user: user,
+    );
   }
 }

--- a/lib/domain/usecase/fetch_initial_posts_usecase.dart
+++ b/lib/domain/usecase/fetch_initial_posts_usecase.dart
@@ -1,12 +1,13 @@
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/domain/repository/post_repository.dart';
+import 'package:share_lingo/domain/entity/app_user.dart';
 
 class FetchInitialPostsUsecase {
   final PostRepository repository;
 
   FetchInitialPostsUsecase(this.repository);
 
-  Future<List<PostEntity>> execute() async {
-    return await repository.fetchInitialPosts();
+  Future<List<PostEntity>> execute({String? filter, AppUser? user}) async {
+    return await repository.fetchInitialPosts(filter: filter, user: user);
   }
 }

--- a/lib/domain/usecase/fetch_lastest_posts_usecase.dart
+++ b/lib/domain/usecase/fetch_lastest_posts_usecase.dart
@@ -1,12 +1,17 @@
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/domain/repository/post_repository.dart';
+import 'package:share_lingo/domain/entity/app_user.dart';
 
 class FetchLastestPostsUsecase {
   final PostRepository repository;
 
   FetchLastestPostsUsecase(this.repository);
 
-  Future<List<PostEntity>> execute(PostEntity firstPost) async {
-    return await repository.fetchLatestPosts(firstPost);
+  Future<List<PostEntity>> execute(
+      PostEntity firstPost, {
+        String? filter,
+        AppUser? user,
+      }) async {
+    return await repository.fetchLatestPosts(firstPost, filter: filter, user: user);
   }
 }

--- a/lib/domain/usecase/fetch_older_posts_usecase.dart
+++ b/lib/domain/usecase/fetch_older_posts_usecase.dart
@@ -1,12 +1,17 @@
 import 'package:share_lingo/domain/entity/post_entity.dart';
 import 'package:share_lingo/domain/repository/post_repository.dart';
+import 'package:share_lingo/domain/entity/app_user.dart';
 
 class FetchOlderPostsUsecase {
   final PostRepository repository;
 
   FetchOlderPostsUsecase(this.repository);
 
-  Future<List<PostEntity>> execute(PostEntity lastPost) async {
-    return await repository.fetchOlderPosts(lastPost);
+  Future<List<PostEntity>> execute(
+      PostEntity lastPost, {
+        String? filter,
+        AppUser? user,
+      }) async {
+    return await repository.fetchOlderPosts(lastPost, filter: filter, user: user);
   }
 }

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_tab.dart';
+import 'package:share_lingo/presentation/pages/home/tabs/feed/posts_feed_tab.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/profile/my_profile_tab.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/write/post_write_tab.dart';
 import 'package:share_lingo/presentation/pages/home/widgets/home_bottom_navigation_bar.dart';

--- a/lib/presentation/pages/home/tabs/feed/feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_tab.dart
@@ -1,110 +1,101 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/core/utils/throttler_util.dart';
+import 'package:share_lingo/domain/entity/app_user.dart';
 import 'package:share_lingo/presentation/pages/home/tabs/feed/feed_view_model.dart';
 import 'package:share_lingo/presentation/pages/home/widgets/post_item.dart';
 
-import '../../../../../app/constants/app_colors.dart';
 
-class FeedTab extends StatelessWidget {
+class PostListContent extends ConsumerWidget {
   final String? uid;
+  final String? filter;
+  final AppUser? user;
 
-  const FeedTab({super.key, this.uid});
+  const PostListContent({super.key, this.uid, this.filter, this.user});
 
   @override
-  Widget build(BuildContext context) {
-    return Consumer(
-      builder: (context, ref, child) {
-        final feedAsync = ref.watch(feedNotifierProvider(uid));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final feedAsync = ref.watch(
+      feedNotifierProvider(FeedQueryArg(uid: uid, filter: filter)),
+    );
 
-        return Column(
-          children: [
-            if (uid == null)
-              AppBar(
-                title: Text(
-                  'ShareLingo',
-                  style: TextStyle(
-                    color: AppColors.primary,
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
+    return feedAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(child: Text('에러 발생: $err')),
+      data: (posts) {
+        if (posts.isEmpty) {
+          return const Center(child: Text('게시글이 없습니다.'));
+        }
+        // throttler 사용
+        final throttler = Throttler(
+          duration: Duration(seconds: 1),
+          callback: () {
+            if (uid == null) {
+              ref
+                  .read(
+                    feedNotifierProvider(
+                      FeedQueryArg(uid: uid, filter: filter),
+                    ).notifier,
+                  )
+                  .fetchOlderPosts();
+            }
+          },
+        );
+        // 무한 스크롤
+        return NotificationListener(
+          onNotification: (notification) {
+            if (notification is ScrollUpdateNotification) {
+              if (notification.metrics.pixels >=
+                  notification.metrics.maxScrollExtent) {
+                throttler.run();
+              }
+            }
+            return true;
+          },
+          // 당겨서 새로고침
+          child: RefreshIndicator(
+            onRefresh: () {
+              if (uid == null) {
+                final throttler = Throttler(
+                  duration: Duration(seconds: 1),
+                  callback: () {
+                    ref
+                        .read(
+                          feedNotifierProvider(
+                            FeedQueryArg(uid: uid, filter: filter),
+                          ).notifier,
+                        )
+                        .fetchLatestPosts();
+                  },
+                );
+                throttler.run();
+              }
+              return Future.value();
+            },
+
+            child: ListView.separated(
+              padding: const EdgeInsets.only(
+                left: 16,
+                right: 16,
+                top: 5,
+                bottom: 100,
               ),
-            Expanded(
-              child: feedAsync.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (err, _) => Center(child: Text('에러 발생: $err')),
-                data: (posts) {
-                  if (posts.isEmpty) {
-                    return const Center(child: Text('게시글이 없습니다.'));
-                  }
-                  // throttler 사용
-                  final throttler = Throttler(
-                    duration: Duration(seconds: 1),
-                    callback: () {
-                      if (uid == null) {
-                        ref
-                            .read(feedNotifierProvider(uid).notifier)
-                            .fetchOlderPosts();
-                      }
-                    },
-                  );
-                  // 무한 스크롤
-                  return NotificationListener(
-                    onNotification: (notification) {
-                      if (notification is ScrollUpdateNotification) {
-                        if (notification.metrics.pixels >=
-                            notification.metrics.maxScrollExtent) {
-                          throttler.run();
-                        }
-                      }
-                      return true;
-                    },
-                    // 당겨서 새로고침
-                    child: RefreshIndicator(
-                      onRefresh: () {
-                        if (uid == null) {
-                          final throttler = Throttler(
-                            duration: Duration(seconds: 1),
-                            callback: () {
-                              ref
-                                  .read(feedNotifierProvider(uid).notifier)
-                                  .fetchLatestPosts();
-                            },
-                          );
-                          throttler.run();
-                        }
-                        return Future.value();
-                      },
+              separatorBuilder: (context, index) {
+                return Column(
+                  children: [
+                    SizedBox(height: 8, width: double.infinity),
+                    Divider(),
+                  ],
+                );
+              },
+              itemCount: posts.length,
+              itemBuilder: (context, index) {
+                final post = posts[index];
 
-                      child: ListView.separated(
-                        padding: const EdgeInsets.only(
-                          left: 16,
-                          right: 16,
-                          top: 5,
-                          bottom: 100,
-                        ),
-                        separatorBuilder: (context, index) {
-                          return Column(
-                            children: [
-                              SizedBox(height: 8, width: double.infinity),
-                              Divider(),
-                            ],
-                          );
-                        },
-                        itemCount: posts.length,
-                        itemBuilder: (context, index) {
-                          final post = posts[index];
-
-                          return PostItem(post: post, displayComments: true);
-                        },
-                      ),
-                    ),
-                  );
-                },
-              ),
+                return PostItem(post: post, displayComments: true);
+              },
             ),
-          ],
+          ),
         );
       },
     );

--- a/lib/presentation/pages/home/tabs/feed/feed_view_model.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_view_model.dart
@@ -9,7 +9,6 @@ import 'package:share_lingo/domain/repository/post_repository.dart';
 import 'package:share_lingo/domain/usecase/fetch_current_updated_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/fetch_initial_posts_usecase.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
-import 'package:share_lingo/domain/usecase/fetch_initial_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/fetch_lastest_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/fetch_older_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/fetch_posts_by_uid_usecase.dart';
@@ -26,10 +25,10 @@ class FeedQueryArg {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is FeedQueryArg &&
-              runtimeType == other.runtimeType &&
-              uid == other.uid &&
-              filter == other.filter;
+      other is FeedQueryArg &&
+          runtimeType == other.runtimeType &&
+          uid == other.uid &&
+          filter == other.filter;
 
   @override
   int get hashCode => uid.hashCode ^ filter.hashCode;
@@ -166,13 +165,22 @@ class FeedNotifier
       // 기존 포스트 최신 50개만 남기기
       List<PostEntity> remainPosts = currentPosts.take(50).toList();
       try {
-        final latestPosts = await latestPostsUsecase.execute(firstPost);
+        final user = ref.read(userGlobalViewModelProvider);
+
+        final latestPosts = await latestPostsUsecase.execute(
+          firstPost,
+          filter: arg.filter,
+          user: user,
+        );
+
         if (latestPosts.isEmpty) return [];
 
         latestPosts.removeWhere((post) => post.uid == firstPost!.uid);
         // 서버에서 firstpost 기준 기존글 50개만 가지고 오기
         final currentUpdatedPosts = await currentUpdatedPostsUsecase.execute(
           firstPost,
+          filter: arg.filter,
+          user: user,
         );
 
         final updateMap = {for (var post in currentUpdatedPosts) post.id: post};

--- a/lib/presentation/pages/home/tabs/feed/feed_view_model.dart
+++ b/lib/presentation/pages/home/tabs/feed/feed_view_model.dart
@@ -5,12 +5,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/core/providers/data_providers.dart';
-import 'package:share_lingo/domain/repository/post_repository.dart';
-import 'package:share_lingo/domain/usecase/fetch_current_updated_posts_usecase.dart';
-import 'package:share_lingo/domain/usecase/fetch_initial_posts_usecase.dart';
 import 'package:share_lingo/domain/entity/post_entity.dart';
-import 'package:share_lingo/domain/usecase/fetch_lastest_posts_usecase.dart';
-import 'package:share_lingo/domain/usecase/fetch_older_posts_usecase.dart';
 import 'package:share_lingo/domain/usecase/fetch_posts_by_uid_usecase.dart';
 
 import '../../../../user_global_view_model.dart';
@@ -37,11 +32,6 @@ class FeedQueryArg {
 
 class FeedNotifier
     extends AutoDisposeFamilyAsyncNotifier<List<PostEntity>, FeedQueryArg> {
-  late final FetchInitialPostsUsecase initialPostsUsecase;
-  late final FetchOlderPostsUsecase olderPostsUsecase;
-  late final FetchLastestPostsUsecase latestPostsUsecase;
-  late final FetchCurrentUpdatedPostsUsecase currentUpdatedPostsUsecase;
-  late final PostRepository repository;
 
   bool _isInitialized = false;
 
@@ -53,11 +43,6 @@ class FeedNotifier
 
     // 중복 초기화 방지
     if (!_isInitialized) {
-      initialPostsUsecase = ref.read(fetchInitialPostsUsecaseProvider);
-      olderPostsUsecase = ref.read(fetchOlderPostsUsecaseProvider);
-      latestPostsUsecase = ref.read(fetchLatestPostsUsecaseProvider);
-      currentUpdatedPostsUsecase = ref.read(fetchCurrentUpdatedPostsUsecase);
-      repository = ref.read(postRepositoryProvider);
       _isInitialized = true;
     }
 
@@ -81,7 +66,7 @@ class FeedNotifier
       }
 
       final user = ref.read(userGlobalViewModelProvider);
-      final posts = await initialPostsUsecase.execute(
+      final posts = await ref.read(fetchInitialPostsUsecaseProvider).execute(
         filter: arg.filter,
         user: user,
       );
@@ -103,7 +88,7 @@ class FeedNotifier
     if (lastPost != null) {
       try {
         final user = ref.read(userGlobalViewModelProvider);
-        final olderPosts = await olderPostsUsecase.execute(
+        final olderPosts = await ref.read(fetchOlderPostsUsecaseProvider).execute(
           lastPost,
           filter: arg.filter,
           user: user,
@@ -133,7 +118,7 @@ class FeedNotifier
     if (firstPost != null) {
       try {
         final user = ref.read(userGlobalViewModelProvider);
-        final latestPosts = await latestPostsUsecase.execute(
+        final latestPosts = await ref.read(fetchLatestPostsUsecaseProvider).execute(
           firstPost,
           filter: arg.filter,
           user: user,
@@ -167,7 +152,7 @@ class FeedNotifier
       try {
         final user = ref.read(userGlobalViewModelProvider);
 
-        final latestPosts = await latestPostsUsecase.execute(
+        final latestPosts = await ref.read(fetchLatestPostsUsecaseProvider).execute(
           firstPost,
           filter: arg.filter,
           user: user,
@@ -177,7 +162,7 @@ class FeedNotifier
 
         latestPosts.removeWhere((post) => post.uid == firstPost!.uid);
         // 서버에서 firstpost 기준 기존글 50개만 가지고 오기
-        final currentUpdatedPosts = await currentUpdatedPostsUsecase.execute(
+        final currentUpdatedPosts = await ref.read(fetchCurrentUpdatedPostsUsecase).execute(
           firstPost,
           filter: arg.filter,
           user: user,

--- a/lib/presentation/pages/home/tabs/feed/posts_feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/posts_feed_tab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../../app/constants/app_colors.dart';
 import '../../../../user_global_view_model.dart';
 import 'feed_tab.dart';
 
@@ -36,7 +37,7 @@ class _FeedTabState extends ConsumerState<FeedTab>
                 title: Text(
                   'ShareLingo',
                   style: TextStyle(
-                    color: Colors.black,
+                    color: AppColors.primary,
                     fontSize: 24,
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/presentation/pages/home/tabs/feed/posts_feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/posts_feed_tab.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_lingo/app/constants/app_colors.dart';
+
+import '../../../../user_global_view_model.dart';
+import 'feed_tab.dart';
+
+class FeedTab extends ConsumerStatefulWidget {
+  final String? uid;
+
+  const FeedTab({super.key, this.uid});
+
+  @override
+  ConsumerState<FeedTab> createState() => _FeedTabState();
+}
+
+class _FeedTabState extends ConsumerState<FeedTab>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 4, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = ref.read(userGlobalViewModelProvider)!;
+
+    return Column(
+      children: [
+        if (widget.uid == null) // Only show on main feed
+          Column(
+            children: [
+              AppBar(
+                title: Text(
+                  'ShareLingo',
+                  style: TextStyle(
+                    color: AppColors.primary,
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              Container(
+                color: Colors.white,
+                child: TabBar(
+                  controller: _tabController,
+                  labelColor: Colors.black,
+                  unselectedLabelColor: Colors.grey,
+                  labelStyle: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 15,
+                  ),
+                  unselectedLabelStyle: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 15,
+                  ),
+                  indicatorColor: Colors.black,
+                  indicatorWeight: 2,
+                  tabs: const [
+                    Tab(text: '전체'),
+                    Tab(text: '추천'),
+                    Tab(text: '동급생'),
+                    Tab(text: '근처'),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        Expanded(
+          child:
+              widget.uid != null
+                  ? PostListContent(uid: widget.uid!)
+                  : TabBarView(
+                    controller: _tabController,
+                    children: [
+                      PostListContent(),
+                      PostListContent(filter: 'recommended', user: user),
+                      PostListContent(filter: 'peers', user: user),
+                      PostListContent(filter: 'nearby', user: user),
+                    ],
+                  ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/home/tabs/feed/posts_feed_tab.dart
+++ b/lib/presentation/pages/home/tabs/feed/posts_feed_tab.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:share_lingo/app/constants/app_colors.dart';
 
 import '../../../../user_global_view_model.dart';
 import 'feed_tab.dart';
@@ -37,7 +36,7 @@ class _FeedTabState extends ConsumerState<FeedTab>
                 title: Text(
                   'ShareLingo',
                   style: TextStyle(
-                    color: AppColors.primary,
+                    color: Colors.black,
                     fontSize: 24,
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -185,7 +185,7 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
     );
 
     if (!mounted) return;
-    await ref.read(feedNotifierProvider(FeedQueryArg()).notifier).refresh();
+    await ref.read(feedNotifierProvider(FeedQueryArg()).notifier).refreshAndUpdatePosts();
     await ref
         .read(
           feedNotifierProvider(

--- a/lib/presentation/pages/home/tabs/write/post_write_tab.dart
+++ b/lib/presentation/pages/home/tabs/write/post_write_tab.dart
@@ -153,11 +153,11 @@ class _PostWriteTabState extends ConsumerState<PostWriteTab> {
     );
 
     if (!mounted) return;
-    await ref.read(feedNotifierProvider(null).notifier).refresh();
+    await ref.read(feedNotifierProvider(FeedQueryArg()).notifier).refresh();
     await ref
         .read(
           feedNotifierProvider(
-            ref.read(userGlobalViewModelProvider)!.id,
+            FeedQueryArg(uid: ref.read(userGlobalViewModelProvider)!.id),
           ).notifier,
         )
         .refresh();

--- a/lib/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart
+++ b/lib/presentation/pages/home/tabs/write/widgets/poll_input_dialog.dart
@@ -1,12 +1,13 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import '../../../../../../app/constants/app_colors.dart';
 
 class PollInputDialog extends StatefulWidget {
   final void Function({
-    required String question,
-    required String option1,
-    required String option2,
-  })
-  onConfirm;
+  required String question,
+  required String option1,
+  required String option2,
+  }) onConfirm;
 
   const PollInputDialog({super.key, required this.onConfirm});
 
@@ -27,58 +28,52 @@ class _PollInputDialogState extends State<PollInputDialog> {
     super.dispose();
   }
 
-  InputDecoration _buildInputDecoration(String label) {
-    return InputDecoration(
-      labelText: label,
-      filled: true,
-      fillColor: Colors.grey.shade100,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-      border: OutlineInputBorder(
+  Widget _buildTextField(TextEditingController controller, String placeholder) {
+    return CupertinoTextField(
+      controller: controller,
+      placeholder: placeholder,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      style: const TextStyle(fontSize: 16),
+      decoration: BoxDecoration(
+        color: CupertinoColors.systemGrey6,
         borderRadius: BorderRadius.circular(12),
-        borderSide: const BorderSide(color: Colors.grey),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: const BorderSide(color: Colors.deepPurple),
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      backgroundColor: Colors.white,
+    return CupertinoAlertDialog(
       title: const Text(
         '투표',
-        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 18,
+        ),
       ),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          TextField(
-            controller: _questionController,
-            decoration: _buildInputDecoration('질문을 입력하세요'),
+      content: Padding(
+        padding: const EdgeInsets.only(top: 12),
+        child: Material(
+          color: Colors.transparent,
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                _buildTextField(_questionController, '질문을 입력하세요'),
+                const SizedBox(height: 12),
+                _buildTextField(_option1Controller, '선택지 1'),
+                const SizedBox(height: 12),
+                _buildTextField(_option2Controller, '선택지 2'),
+              ],
+            ),
           ),
-          const SizedBox(height: 14),
-          TextField(
-            controller: _option1Controller,
-            decoration: _buildInputDecoration('선택지 1'),
-          ),
-          const SizedBox(height: 14),
-          TextField(
-            controller: _option2Controller,
-            decoration: _buildInputDecoration('선택지 2'),
-          ),
-        ],
+        ),
       ),
-      actionsPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
       actions: [
-        TextButton(
+        CupertinoDialogAction(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('취소', style: TextStyle(color: Colors.grey)),
         ),
-        ElevatedButton(
+        CupertinoDialogAction(
           onPressed: () {
             final q = _questionController.text.trim();
             final o1 = _option1Controller.text.trim();
@@ -89,14 +84,14 @@ class _PollInputDialogState extends State<PollInputDialog> {
               Navigator.of(context).pop();
             }
           },
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.deepPurple,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
+          isDefaultAction: true,
+          child: Text(
+            '확인',
+            style: TextStyle(
+              color: AppColors.buttonsBlue,
+              fontWeight: FontWeight.bold,
             ),
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
           ),
-          child: const Text('확인', style: TextStyle(color: Colors.white)),
         ),
       ],
     );

--- a/lib/presentation/pages/home/widgets/post_item.dart
+++ b/lib/presentation/pages/home/widgets/post_item.dart
@@ -39,7 +39,7 @@ class _PostItemState extends ConsumerState<PostItem> {
   @override
   Widget build(BuildContext context) {
     final List<ImageProvider> cachedImages = ref
-        .read(feedNotifierProvider(null).notifier)
+        .read(feedNotifierProvider(FeedQueryArg()).notifier)
         .getCachedImageProviders(widget.post);
 
     final DateTime now = ref.watch(timeAgoNotifierProvider);

--- a/lib/presentation/pages/profile_edit/edit_profile_page.dart
+++ b/lib/presentation/pages/profile_edit/edit_profile_page.dart
@@ -21,8 +21,6 @@ class EditProfilePage extends ConsumerStatefulWidget {
 
 class _EditProfilePageState extends ConsumerState<EditProfilePage> {
   late TextEditingController nameController;
-  late TextEditingController nativeLanguageController;
-  late TextEditingController targetLanguageController;
   late TextEditingController bioController;
   late TextEditingController languageLearningGoalController;
   late TextEditingController hobbiesController;
@@ -35,12 +33,6 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
   void initState() {
     super.initState();
     nameController = TextEditingController(text: widget.user.name);
-    nativeLanguageController = TextEditingController(
-      text: widget.user.nativeLanguage ?? '',
-    );
-    targetLanguageController = TextEditingController(
-      text: widget.user.targetLanguage ?? '',
-    );
     bioController = TextEditingController(text: widget.user.bio ?? '');
     hobbiesController = TextEditingController(text: widget.user.hobbies ?? '');
     languageLearningGoalController = TextEditingController(
@@ -58,8 +50,6 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
   @override
   void dispose() {
     nameController.dispose();
-    nativeLanguageController.dispose();
-    targetLanguageController.dispose();
     bioController.dispose();
     hobbiesController.dispose();
     languageLearningGoalController.dispose();
@@ -124,8 +114,8 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
 
     final updatedUser = widget.user.copyWith(
       name: nameController.text,
-      nativeLanguage: nativeLanguageController.text,
-      targetLanguage: targetLanguageController.text,
+      nativeLanguage: stateRead.nativeLanguage,
+      targetLanguage: stateRead.targetLanguage,
       district: stateRead.district,
       location: stateRead.location,
       bio: bioController.text,

--- a/lib/presentation/pages/profile_edit/edit_profile_page.dart
+++ b/lib/presentation/pages/profile_edit/edit_profile_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:share_lingo/presentation/widgets/input_decorations.dart';
 import '../../../core/utils/dialogue_util.dart';
+import '../../../core/utils/general_utils.dart';
 import '../../../core/utils/snackbar_util.dart';
 import '../../../domain/entity/app_user.dart';
 import '../../widgets/language_selection_modal.dart';
@@ -58,38 +59,9 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
   }
 
   Future<void> _pickBirthdate() async {
-    final now = DateTime.now();
-    final picked = await showDatePicker(
+    final picked = await GeneralUtils.pickBirthdate(
       context: context,
-      locale: Locale('ko'),
-      initialDate: birthdate ?? now.subtract(const Duration(days: 365 * 20)),
-      firstDate: DateTime(1900),
-      lastDate: now,
-      builder: (context, child) {
-        return Theme(
-          data: Theme.of(context).copyWith(
-            colorScheme: const ColorScheme.light(
-              primary: Colors.blueAccent,
-              // Example crimson color
-              onPrimary: Colors.white,
-              // Text color on primary (e.g. header text)
-              surface: Colors.white,
-              // Dialog background color
-              onSurface: Colors.black87, // Default text color
-            ),
-            datePickerTheme: const DatePickerThemeData(
-              backgroundColor: Colors.white,
-              headerBackgroundColor: Colors.blueAccent,
-              // crimson
-              headerForegroundColor: Colors.white,
-              dayForegroundColor: WidgetStatePropertyAll(Colors.black87),
-              todayForegroundColor: WidgetStatePropertyAll(Colors.white),
-              todayBackgroundColor: WidgetStatePropertyAll(Colors.blueAccent),
-            ),
-          ),
-          child: child!,
-        );
-      },
+      initialDate: birthdate,
     );
     if (picked != null) {
       birthdate = picked;

--- a/lib/presentation/widgets/comment_section.dart
+++ b/lib/presentation/widgets/comment_section.dart
@@ -59,10 +59,10 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
         .add(commentDto.toMap());
 
     // Update the post's comment count
-    await FirebaseFirestore.instance
-        .collection('posts')
-        .doc(widget.postId)
-        .update({'commentCount': FieldValue.increment(1)});
+    // await FirebaseFirestore.instance
+    //     .collection('posts')
+    //     .doc(widget.postId)
+    //     .update({'commentCount': FieldValue.increment(1)});
 
     _commentController.clear();
     setState(() {
@@ -94,10 +94,10 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
         .delete();
 
     // Update the post's comment count
-    await FirebaseFirestore.instance
-        .collection('posts')
-        .doc(widget.postId)
-        .update({'commentCount': FieldValue.increment(-1)});
+    // await FirebaseFirestore.instance
+    //     .collection('posts')
+    //     .doc(widget.postId)
+    //     .update({'commentCount': FieldValue.increment(-1)});
   }
 
   Future<void> _toggleReaction(String commentId, String emoji) async {

--- a/lib/presentation/widgets/profile_layout.dart
+++ b/lib/presentation/widgets/profile_layout.dart
@@ -3,7 +3,7 @@ import 'package:share_lingo/app/constants/app_colors.dart';
 import 'package:share_lingo/presentation/widgets/profile_images.dart';
 
 import '../../domain/entity/app_user.dart';
-import '../pages/home/tabs/feed/feed_tab.dart';
+import '../pages/home/tabs/feed/posts_feed_tab.dart';
 
 class ProfileLayout extends StatelessWidget {
   final AppUser user;


### PR DESCRIPTION
- 피드 탭 상단에 TabBar 추가 (전체 / 추천 / 동급생 / 근처)
- 각 탭에 맞는 필터 적용 로직 구현
  - 추천: 내 학습 언어와 맞는 사용자 글
  - 동급생: 내 모국어 & 학습 언어 동일한 사용자 글
  - 근처: 같은 지역(읍면동) 사용자 글
- FeedQueryArg 클래스 도입하여 uid와 filter를 함께 전달
- FeedNotifier를 리팩터링하여 필터 및 사용자 정보 처리 가능하도록 수정
- 각 UseCase에 filter와 user를 파라미터로 전달하도록 수정

- fix(EditProfilePage): 모국어랑 학습 언어 업데이트 안 되던 오류 해결
- feat: Change FeedTab page app bar text color to black to match the tabs