### PR TITLE
온보딩 시작 시 약관 및 개인정보처리방침 동의 기능 추가

### DIFF
--- a/lib/presentation/pages/onboarding/onboarding_page.dart
+++ b/lib/presentation/pages/onboarding/onboarding_page.dart
@@ -1,19 +1,123 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/presentation/pages/onboarding/tabs/enable_location_tab.dart';
 import 'package:share_lingo/presentation/pages/onboarding/tabs/input_bio_tab.dart';
-import 'package:share_lingo/presentation/pages/onboarding/tabs/language_selection_tab.dart';
 import 'package:share_lingo/presentation/pages/onboarding/tabs/input_name_date_tab.dart';
+import 'package:share_lingo/presentation/pages/onboarding/tabs/language_selection_tab.dart';
 import 'package:share_lingo/presentation/pages/onboarding/widgets/step_progress_header.dart';
+import 'package:url_launcher/url_launcher.dart';
+
 import 'onboarding_view_model.dart';
 
-class OnboardingPage extends ConsumerWidget {
-  final PageController _pageController = PageController();
-
-  OnboardingPage({super.key});
+class OnboardingPage extends ConsumerStatefulWidget {
+  const OnboardingPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends ConsumerState<OnboardingPage> {
+  final PageController _pageController = PageController();
+  bool _dialogShown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_dialogShown) {
+      Future.delayed(Duration.zero, _showConsentDialog);
+      _dialogShown = true;
+    }
+  }
+
+  Future<void> _showConsentDialog() async {
+    bool accepted = false;
+
+    await showCupertinoDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return CupertinoAlertDialog(
+              title: const Text("이용약관 및 개인정보처리방침"),
+              content: Column(
+                children: [
+                  const SizedBox(height: 10),
+                  Text(
+                    "앱 사용을 위해 아래 약관에 동의해 주세요.",
+                    style: TextStyle(fontSize: 14),
+                  ),
+                  const SizedBox(height: 17),
+                  GestureDetector(
+                    onTap:
+                        () => launchUrl(
+                      Uri.parse('https://englim.me/share-lingo-page/terms'),
+                    ),
+                    child: Text(
+                      "📜  이용약관 보기",
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: CupertinoColors.activeBlue,
+                        // decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  GestureDetector(
+                    onTap:
+                        () => launchUrl(
+                      Uri.parse(
+                        'https://englim.me/share-lingo-page',
+                      ),
+                    ),
+                    child: Text(
+                      "📄  개인정보처리방침 보기",
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: CupertinoColors.activeBlue,
+                        // decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: Transform.scale(
+                          scale: 1.3, // makes the checkbox larger
+                          child: CupertinoCheckbox(
+                            value: accepted,
+                            onChanged: (bool? value) {
+                              setState(() => accepted = value ?? false);
+                            },
+                          ),
+                        ),
+                      ),
+                      const Text("위 약관에 동의합니다.", style: TextStyle(fontSize: 15),),
+                    ],
+                  ),
+                ],
+              ),
+              actions: [
+                CupertinoDialogAction(
+                  child: const Text("확인"),
+                  onPressed:
+                      accepted ? () => Navigator.of(context).pop() : null,
+                  isDefaultAction: true,
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final currentPage = ref.watch(onboardingViewModelProvider);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
- 앱 최초 진입 시 표시되는 Cupertino 스타일의 약관 동의 팝업 구현
- 이용약관 및 개인정보처리방침 링크 포함
- 동의 체크박스를 통해 수락해야 다음 단계로 진행 가능
- URL launcher 사용하여 외부 브라우저로 해당 문서 열기