### PR TITLE
이용약관 및 개인정보 동의 로직 로그인 페이지로 이동 + 설정 메뉴에도 추가 및 본인 게시글 제외 처리

### DIFF
--- a/lib/data/data_source/post_remote_data_source.dart
+++ b/lib/data/data_source/post_remote_data_source.dart
@@ -38,9 +38,11 @@ class PostRemoteDataSource {
     final query = _applyFilter(base, filter, user);
     final snapshot = await query.get();
 
-    return snapshot.docs
-        .map((doc) => PostDto.fromMap(doc.id, doc.data()))
-        .toList();
+    final posts =
+        snapshot.docs
+            .map((doc) => PostDto.fromMap(doc.id, doc.data()))
+            .toList();
+    return _excludeSelf(posts, filter, user);
   }
 
   Future<List<PostDto>> fetchOlderPosts(
@@ -57,9 +59,11 @@ class PostRemoteDataSource {
     final query = _applyFilter(base, filter, user);
     final snapshot = await query.get();
 
-    return snapshot.docs
-        .map((doc) => PostDto.fromMap(doc.id, doc.data()))
-        .toList();
+    final posts =
+        snapshot.docs
+            .map((doc) => PostDto.fromMap(doc.id, doc.data()))
+            .toList();
+    return _excludeSelf(posts, filter, user);
   }
 
   Future<List<PostDto>> fetchLatestPosts(
@@ -80,7 +84,18 @@ class PostRemoteDataSource {
         snapshot.docs
             .map((doc) => PostDto.fromMap(doc.id, doc.data()))
             .toList();
-    return reversedList.reversed.toList();
+    return _excludeSelf(reversedList.reversed.toList(), filter, user);
+  }
+
+  List<PostDto> _excludeSelf(
+    List<PostDto> posts,
+    String? filter,
+    AppUser? user,
+  ) {
+    if (filter != null && user != null) {
+      return posts.where((post) => post.uid != user.id).toList();
+    }
+    return posts;
   }
 
   Query<Map<String, dynamic>> _applyFilter(
@@ -122,9 +137,10 @@ class PostRemoteDataSource {
     final query = _applyFilter(base, filter, user);
     final snapshot = await query.get();
 
-    return snapshot.docs
+    final posts = snapshot.docs
         .map((doc) => PostDto.fromMap(doc.id, doc.data()))
         .toList();
+    return _excludeSelf(posts, filter, user);
   }
 
   Future<void> updatePost({

--- a/lib/presentation/pages/login/login_view_model.dart
+++ b/lib/presentation/pages/login/login_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:share_lingo/core/utils/logger.dart';
 
 import '../../../domain/entity/app_user.dart';
@@ -6,22 +7,46 @@ import '../../../domain/usecase/sign_in_with_google_usecase.dart';
 
 class LoginState {
   final bool isLoading;
+  final bool hasAgreedToTerms;
   final String? errorMessage;
 
-  const LoginState({this.isLoading = false, this.errorMessage});
+  const LoginState({
+    this.isLoading = false,
+    this.hasAgreedToTerms = false,
+    this.errorMessage,
+  });
 
-  LoginState copyWith({bool? isLoading, String? errorMessage}) {
+  LoginState copyWith({
+    bool? isLoading,
+    bool? hasAgreedToTerms,
+    String? errorMessage,
+  }) {
     return LoginState(
       isLoading: isLoading ?? this.isLoading,
+      hasAgreedToTerms: hasAgreedToTerms ?? this.hasAgreedToTerms,
       errorMessage: errorMessage,
     );
   }
 }
 
 class LoginViewModel extends Notifier<LoginState> {
+  static const String _agreementKey = 'user_agreed_to_terms';
+
   @override
   LoginState build() {
     return const LoginState();
+  }
+
+  Future<void> loadAgreement() async {
+    final prefs = await SharedPreferences.getInstance();
+    final agreed = prefs.getBool(_agreementKey) ?? false;
+    state = state.copyWith(hasAgreedToTerms: agreed);
+  }
+
+  Future<void> setAgreement(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_agreementKey, value);
+    state = state.copyWith(hasAgreedToTerms: value);
   }
 
   Future<AppUser?> signIn() async {

--- a/lib/presentation/pages/onboarding/onboarding_page.dart
+++ b/lib/presentation/pages/onboarding/onboarding_page.dart
@@ -1,123 +1,19 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_lingo/presentation/pages/onboarding/tabs/enable_location_tab.dart';
 import 'package:share_lingo/presentation/pages/onboarding/tabs/input_bio_tab.dart';
-import 'package:share_lingo/presentation/pages/onboarding/tabs/input_name_date_tab.dart';
 import 'package:share_lingo/presentation/pages/onboarding/tabs/language_selection_tab.dart';
+import 'package:share_lingo/presentation/pages/onboarding/tabs/input_name_date_tab.dart';
 import 'package:share_lingo/presentation/pages/onboarding/widgets/step_progress_header.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 import 'onboarding_view_model.dart';
 
-class OnboardingPage extends ConsumerStatefulWidget {
-  const OnboardingPage({super.key});
-
-  @override
-  ConsumerState<OnboardingPage> createState() => _OnboardingPageState();
-}
-
-class _OnboardingPageState extends ConsumerState<OnboardingPage> {
+class OnboardingPage extends ConsumerWidget {
   final PageController _pageController = PageController();
-  bool _dialogShown = false;
+
+  OnboardingPage({super.key});
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (!_dialogShown) {
-      Future.delayed(Duration.zero, _showConsentDialog);
-      _dialogShown = true;
-    }
-  }
-
-  Future<void> _showConsentDialog() async {
-    bool accepted = false;
-
-    await showCupertinoDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            return CupertinoAlertDialog(
-              title: const Text("이용약관 및 개인정보처리방침"),
-              content: Column(
-                children: [
-                  const SizedBox(height: 10),
-                  Text(
-                    "앱 사용을 위해 아래 약관에 동의해 주세요.",
-                    style: TextStyle(fontSize: 14),
-                  ),
-                  const SizedBox(height: 17),
-                  GestureDetector(
-                    onTap:
-                        () => launchUrl(
-                      Uri.parse('https://englim.me/share-lingo-page/terms'),
-                    ),
-                    child: Text(
-                      "📜  이용약관 보기",
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: CupertinoColors.activeBlue,
-                        // decoration: TextDecoration.underline,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  GestureDetector(
-                    onTap:
-                        () => launchUrl(
-                      Uri.parse(
-                        'https://englim.me/share-lingo-page',
-                      ),
-                    ),
-                    child: Text(
-                      "📄  개인정보처리방침 보기",
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: CupertinoColors.activeBlue,
-                        // decoration: TextDecoration.underline,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 14),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(top: 2),
-                        child: Transform.scale(
-                          scale: 1.3, // makes the checkbox larger
-                          child: CupertinoCheckbox(
-                            value: accepted,
-                            onChanged: (bool? value) {
-                              setState(() => accepted = value ?? false);
-                            },
-                          ),
-                        ),
-                      ),
-                      const Text("위 약관에 동의합니다.", style: TextStyle(fontSize: 15),),
-                    ],
-                  ),
-                ],
-              ),
-              actions: [
-                CupertinoDialogAction(
-                  onPressed:
-                      accepted ? () => Navigator.of(context).pop() : null,
-                  isDefaultAction: true,
-                  child: const Text("확인"),
-                ),
-              ],
-            );
-          },
-        );
-      },
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final currentPage = ref.watch(onboardingViewModelProvider);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/presentation/pages/post/post_detail_page.dart
+++ b/lib/presentation/pages/post/post_detail_page.dart
@@ -65,13 +65,16 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
           body: SingleChildScrollView(
             child: Column(
               children: [
-                PostItem(post: _post, displayComments: false),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: PostItem(post: _post, displayComments: false),
+                ),
                 if (_post.isPoll)
                   Padding(
-                    padding: const EdgeInsets.only(top: 16.0),
+                    padding: const EdgeInsets.only(top: 6, left: 8, right: 8),
                     child: PollPostCard(post: _post, now: DateTime.now()),
                   ),
-                const Divider(),
+                // const Divider(),
                 CommentSection(postId: _post.id),
               ],
             ),

--- a/lib/presentation/pages/report/comment_report_page.dart
+++ b/lib/presentation/pages/report/comment_report_page.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:share_lingo/presentation/user_global_view_model.dart';
+
+class CommentReportPage extends ConsumerStatefulWidget {
+  final String postId;
+  final String commentId;
+  final String commentContent;
+
+  const CommentReportPage({
+    super.key,
+    required this.postId,
+    required this.commentId,
+    required this.commentContent,
+  });
+
+  @override
+  ConsumerState<CommentReportPage> createState() => _CommentReportPageState();
+}
+
+class _CommentReportPageState extends ConsumerState<CommentReportPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _reasonController = TextEditingController();
+  String _selectedReason = '스팸';
+  bool _isSubmitting = false;
+
+  final List<String> _reportReasons = [
+    '스팸',
+    '부적절한 콘텐츠',
+    '괴롭힘',
+    '혐오 발언',
+    '폭력',
+    '기타',
+  ];
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitReport() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      final user = ref.read(userGlobalViewModelProvider);
+      if (user == null) throw Exception('User not authenticated');
+
+      await FirebaseFirestore.instance
+          .collection('posts')
+          .doc(widget.postId)
+          .collection('comments')
+          .doc(widget.commentId)
+          .collection('reports')
+          .add({
+        'postId': widget.postId,
+        'commentId': widget.commentId,
+        'commentContent': widget.commentContent,
+        'reporterId': user.id,
+        'reporterName': user.name,
+        'reason': _selectedReason,
+        'description': _reasonController.text,
+        'createdAt': FieldValue.serverTimestamp(),
+        'status': 'pending',
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('신고가 접수되었습니다.')));
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('신고 접수 중 오류가 발생했습니다: $e')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('댓글 신고')),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const Text(
+              '신고 사유를 선택해주세요',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            ..._reportReasons.map(
+                  (reason) => RadioListTile<String>(
+                title: Text(reason),
+                value: reason,
+                groupValue: _selectedReason,
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() => _selectedReason = value);
+                  }
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _reasonController,
+              decoration: const InputDecoration(
+                labelText: '추가 설명 (선택사항)',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '내용을 입력하세요';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _isSubmitting ? null : _submitReport,
+              child:
+              _isSubmitting
+                  ? const CircularProgressIndicator()
+                  : const Text('신고하기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/settings/settings_page.dart
+++ b/lib/presentation/pages/settings/settings_page.dart
@@ -41,6 +41,15 @@ class SettingsPage extends ConsumerWidget {
     }
   }
 
+  Future<void> _launchUrl(BuildContext context, String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.inAppBrowserView);
+    } else {
+      SnackbarUtil.showSnackBar(context, 'URL을 열 수 없습니다');
+    }
+  }
+
   Future<void> _logout(BuildContext context, WidgetRef ref) async {
     try {
       final result = await DialogueUtil.showAppCupertinoDialog(
@@ -97,6 +106,22 @@ class SettingsPage extends ConsumerWidget {
             // margin: EdgeInsetsDirectional.only(start: 18, end: 18, top: 7, bottom: 7),
             title: Text('정보', style: AppStyles.mediumText),
             tiles: [
+              SettingsTile(
+                leading: const Icon(Icons.article_outlined),
+                title: Text('이용약관'),
+                onPressed: (context) => _launchUrl(
+                  context,
+                  'https://englim.me/share-lingo-page/terms',
+                ),
+              ),
+              SettingsTile(
+                leading: const Icon(Icons.vpn_key),
+                title: Text('개인정보처리방침'),
+                onPressed: (context) => _launchUrl(
+                  context,
+                  'https://englim.me/share-lingo-page',
+                ),
+              ),
               SettingsTile(
                 leading: const Icon(Icons.email),
                 title: Text('개발자들에게 문의'),

--- a/lib/presentation/pages/settings/settings_page.dart
+++ b/lib/presentation/pages/settings/settings_page.dart
@@ -46,6 +46,7 @@ class SettingsPage extends ConsumerWidget {
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri, mode: LaunchMode.inAppBrowserView);
     } else {
+      if (!context.mounted) return;
       SnackbarUtil.showSnackBar(context, 'URL을 열 수 없습니다');
     }
   }

--- a/lib/presentation/widgets/comment_section.dart
+++ b/lib/presentation/widgets/comment_section.dart
@@ -184,7 +184,7 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
                   child: TextField(
                     controller: _commentController,
                     decoration: InputDecoration(
-                      hintText: 'Add a comment...',
+                      hintText: '댓글을 입력하세요...',
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
                         borderSide: BorderSide.none,
@@ -263,6 +263,7 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
                   _isEditing.putIfAbsent(comment.id, () => false);
 
                   return Card(
+                    color: Colors.white,
                     margin: const EdgeInsets.symmetric(
                       horizontal: 16,
                       vertical: 8,
@@ -569,6 +570,7 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (error, stack) => Center(child: Text('Error: $error')),
         ),
+        SizedBox(height: 50,),
       ],
     );
   }

--- a/lib/presentation/widgets/comment_section.dart
+++ b/lib/presentation/widgets/comment_section.dart
@@ -9,6 +9,8 @@ import 'package:share_lingo/presentation/user_global_view_model.dart';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/foundation.dart' as foundation;
 
+import '../pages/report/comment_report_page.dart';
+
 class CommentSection extends ConsumerStatefulWidget {
   final String postId;
 
@@ -301,149 +303,230 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
                                   ],
                                 ),
                               ),
-                              if (isOwner)
-                                IconButton(
-                                  icon: const Icon(Icons.more_vert),
-                                  onPressed: () {
-                                    showModalBottomSheet(
-                                      context: context,
-                                      isScrollControlled: true,
-                                      backgroundColor: Colors.grey[200],
-                                      shape: const RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.vertical(
-                                          top: Radius.circular(16),
-                                        ),
+                              IconButton(
+                                icon: const Icon(Icons.more_vert),
+                                onPressed: () {
+                                  showModalBottomSheet(
+                                    context: context,
+                                    isScrollControlled: true,
+                                    backgroundColor: Colors.grey[200],
+                                    shape: const RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.vertical(
+                                        top: Radius.circular(16),
                                       ),
-                                      builder:
-                                          (context) => Padding(
-                                            padding: const EdgeInsets.only(
-                                              top: 8,
-                                              bottom: 24,
+                                    ),
+                                    builder:
+                                        (context) => Padding(
+                                      padding: const EdgeInsets.only(
+                                        top: 8,
+                                        bottom: 24,
+                                      ),
+                                      child: Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Container(
+                                            width: 40,
+                                            height: 5,
+                                            decoration: BoxDecoration(
+                                              color: Colors.grey[400],
+                                              borderRadius:
+                                              BorderRadius.circular(10),
                                             ),
-                                            child: Column(
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: [
-                                                Container(
-                                                  width: 40,
-                                                  height: 5,
-                                                  decoration: BoxDecoration(
-                                                    color: Colors.grey[400],
-                                                    borderRadius:
-                                                        BorderRadius.circular(
-                                                          10,
-                                                        ),
-                                                  ),
-                                                  margin: const EdgeInsets.only(
-                                                    bottom: 12,
-                                                  ),
-                                                ),
-                                                Card(
-                                                  margin:
-                                                      const EdgeInsets.symmetric(
-                                                        horizontal: 12,
-                                                        vertical: 6,
-                                                      ),
-                                                  shape: RoundedRectangleBorder(
-                                                    borderRadius:
-                                                        BorderRadius.circular(
-                                                          14,
-                                                        ),
-                                                  ),
-                                                  elevation: 0,
-                                                  color: Colors.white,
-                                                  child: ListTile(
-                                                    contentPadding:
-                                                        const EdgeInsets.symmetric(
-                                                          horizontal: 16,
-                                                          vertical: 6,
-                                                        ),
-                                                    title: const Text(
-                                                      '수정',
-                                                      style: TextStyle(
-                                                        fontSize: 16,
-                                                        fontWeight:
-                                                            FontWeight.w500,
-                                                      ),
-                                                    ),
-                                                    trailing: const Icon(
-                                                      Icons.edit,
-                                                    ),
-                                                    onTap: () {
-                                                      setState(() {
-                                                        _isEditing[comment.id] =
-                                                            true;
-                                                      });
-                                                      Navigator.pop(context);
-                                                    },
-                                                  ),
-                                                ),
-                                                Card(
-                                                  margin:
-                                                      const EdgeInsets.symmetric(
-                                                        horizontal: 12,
-                                                        vertical: 6,
-                                                      ),
-                                                  shape: RoundedRectangleBorder(
-                                                    borderRadius:
-                                                        BorderRadius.circular(
-                                                          14,
-                                                        ),
-                                                  ),
-                                                  elevation: 0,
-                                                  color: Colors.white,
-                                                  child: ListTile(
-                                                    contentPadding:
-                                                        const EdgeInsets.symmetric(
-                                                          horizontal: 16,
-                                                          vertical: 6,
-                                                        ),
-                                                    title: const Text(
-                                                      '삭제',
-                                                      style: TextStyle(
-                                                        fontSize: 16,
-                                                        fontWeight:
-                                                            FontWeight.w500,
-                                                        color: Colors.red,
-                                                      ),
-                                                    ),
-                                                    trailing: const Icon(
-                                                      Icons.delete,
-                                                      color: Colors.red,
-                                                    ),
-                                                    onTap: () async {
-                                                      Navigator.pop(context); // Close the bottom sheet first
-
-                                                      final confirm = await showCupertinoDialog<bool>(
-                                                        context: context,
-                                                        builder: (dialogContext) => CupertinoAlertDialog(
-                                                          title: const Text('정말 삭제할까요?'),
-                                                          content: const Text('삭제된 댓글은 복구할 수 없습니다.'),
-                                                          actions: [
-                                                            CupertinoDialogAction(
-                                                              onPressed: () => Navigator.pop(dialogContext, false),
-                                                              child: const Text('취소'),
-                                                            ),
-                                                            CupertinoDialogAction(
-                                                              isDestructiveAction: true,
-                                                              onPressed: () => Navigator.pop(dialogContext, true),
-                                                              child: const Text('삭제'),
-                                                            ),
-                                                          ],
-                                                        ),
-                                                      );
-
-                                                      if (confirm == true) {
-                                                        _deleteComment(comment.id);
-                                                      }
-                                                    },
-                                                  ),
-                                                ),
-                                              ],
+                                            margin: const EdgeInsets.only(
+                                              bottom: 12,
                                             ),
                                           ),
-                                    );
-                                  },
-                                ),
+                                          if (isOwner) ...[
+                                            Card(
+                                              margin:
+                                              const EdgeInsets.symmetric(
+                                                horizontal: 12,
+                                                vertical: 6,
+                                              ),
+                                              shape: RoundedRectangleBorder(
+                                                borderRadius:
+                                                BorderRadius.circular(
+                                                  14,
+                                                ),
+                                              ),
+                                              elevation: 0,
+                                              color: Colors.white,
+                                              child: ListTile(
+                                                contentPadding:
+                                                const EdgeInsets.symmetric(
+                                                  horizontal: 16,
+                                                  vertical: 6,
+                                                ),
+                                                title: const Text(
+                                                  '수정',
+                                                  style: TextStyle(
+                                                    fontSize: 16,
+                                                    fontWeight:
+                                                    FontWeight.w500,
+                                                  ),
+                                                ),
+                                                trailing: const Icon(
+                                                  Icons.edit,
+                                                ),
+                                                onTap: () {
+                                                  setState(() {
+                                                    _isEditing[comment.id] =
+                                                    true;
+                                                  });
+                                                  Navigator.pop(context);
+                                                },
+                                              ),
+                                            ),
+                                            Card(
+                                              margin:
+                                              const EdgeInsets.symmetric(
+                                                horizontal: 12,
+                                                vertical: 6,
+                                              ),
+                                              shape: RoundedRectangleBorder(
+                                                borderRadius:
+                                                BorderRadius.circular(
+                                                  14,
+                                                ),
+                                              ),
+                                              elevation: 0,
+                                              color: Colors.white,
+                                              child: ListTile(
+                                                contentPadding:
+                                                const EdgeInsets.symmetric(
+                                                  horizontal: 16,
+                                                  vertical: 6,
+                                                ),
+                                                title: const Text(
+                                                  '삭제',
+                                                  style: TextStyle(
+                                                    fontSize: 16,
+                                                    fontWeight:
+                                                    FontWeight.w500,
+                                                    color: Colors.red,
+                                                  ),
+                                                ),
+                                                trailing: const Icon(
+                                                  Icons.delete,
+                                                  color: Colors.red,
+                                                ),
+                                                onTap: () async {
+                                                  Navigator.pop(context);
+                                                  final confirm = await showCupertinoDialog<
+                                                      bool
+                                                  >(
+                                                    context: context,
+                                                    builder:
+                                                        (
+                                                        dialogContext,
+                                                        ) => CupertinoAlertDialog(
+                                                      title: const Text(
+                                                        '정말 삭제할까요?',
+                                                      ),
+                                                      content: const Text(
+                                                        '삭제된 댓글은 복구할 수 없습니다.',
+                                                      ),
+                                                      actions: [
+                                                        CupertinoDialogAction(
+                                                          onPressed:
+                                                              () => Navigator.pop(
+                                                            dialogContext,
+                                                            false,
+                                                          ),
+                                                          child:
+                                                          const Text(
+                                                            '취소',
+                                                          ),
+                                                        ),
+                                                        CupertinoDialogAction(
+                                                          isDestructiveAction:
+                                                          true,
+                                                          onPressed:
+                                                              () => Navigator.pop(
+                                                            dialogContext,
+                                                            true,
+                                                          ),
+                                                          child:
+                                                          const Text(
+                                                            '삭제',
+                                                          ),
+                                                        ),
+                                                      ],
+                                                    ),
+                                                  );
+
+                                                  if (confirm == true) {
+                                                    _deleteComment(
+                                                      comment.id,
+                                                    );
+                                                  }
+                                                },
+                                              ),
+                                            ),
+                                          ],
+                                          if (!isOwner)
+                                            Card(
+                                              margin:
+                                              const EdgeInsets.symmetric(
+                                                horizontal: 12,
+                                                vertical: 6,
+                                              ),
+                                              shape: RoundedRectangleBorder(
+                                                borderRadius:
+                                                BorderRadius.circular(
+                                                  14,
+                                                ),
+                                              ),
+                                              elevation: 0,
+                                              color: Colors.white,
+                                              child: ListTile(
+                                                contentPadding:
+                                                const EdgeInsets.symmetric(
+                                                  horizontal: 16,
+                                                  vertical: 6,
+                                                ),
+                                                title: const Text(
+                                                  '신고',
+                                                  style: TextStyle(
+                                                    fontSize: 16,
+                                                    fontWeight:
+                                                    FontWeight.w500,
+                                                    color: Colors.red,
+                                                  ),
+                                                ),
+                                                trailing: const Icon(
+                                                  Icons.flag,
+                                                  color: Colors.red,
+                                                ),
+                                                onTap: () {
+                                                  Navigator.pop(context);
+                                                  Navigator.push(
+                                                    context,
+                                                    MaterialPageRoute(
+                                                      builder:
+                                                          (
+                                                          context,
+                                                          ) => CommentReportPage(
+                                                        postId:
+                                                        widget
+                                                            .postId,
+                                                        commentId:
+                                                        comment.id,
+                                                        commentContent:
+                                                        comment
+                                                            .content,
+                                                      ),
+                                                    ),
+                                                  );
+                                                },
+                                              ),
+                                            ),
+                                        ],
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
                             ],
                           ),
                           const SizedBox(height: 8),

--- a/lib/presentation/widgets/comment_section.dart
+++ b/lib/presentation/widgets/comment_section.dart
@@ -304,7 +304,7 @@ class _CommentSectionState extends ConsumerState<CommentSection> {
                                 ),
                               ),
                               IconButton(
-                                icon: const Icon(Icons.more_vert),
+                                icon: const Icon(CupertinoIcons.ellipsis),
                                 onPressed: () {
                                   showModalBottomSheet(
                                     context: context,

--- a/lib/presentation/widgets/profile_layout.dart
+++ b/lib/presentation/widgets/profile_layout.dart
@@ -32,29 +32,40 @@ class ProfileLayout extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Row(
-                          children: [
-                            SizedBox(
-                              width: (MediaQuery.of(context).size.width) * 0.7,
-                              child: Text(
-                                user.name,
-                                style: const TextStyle(
-                                  fontSize: 22,
-                                  fontWeight: FontWeight.bold,
+                        LayoutBuilder(
+                          builder: (context, constraints) {
+                            return Row(
+                              children: [
+                                ConstrainedBox(
+                                  constraints: BoxConstraints(
+                                    maxWidth:
+                                        user.age != null
+                                            ? constraints.maxWidth - 50
+                                            : constraints.maxWidth,
+                                  ),
+                                  child: Text(
+                                    user.name,
+                                    style: const TextStyle(
+                                      fontSize: 22,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                    maxLines: 1,
+                                  ),
                                 ),
-                              ),
-                            ),
-                            if (user.age != null) ...[
-                              const SizedBox(width: 7),
-                              Text(
-                                '${user.age}세',
-                                style: const TextStyle(
-                                  fontSize: 16,
-                                  color: Colors.black54,
-                                ),
-                              ),
-                            ],
-                          ],
+                                if (user.age != null) ...[
+                                  const SizedBox(width: 7),
+                                  Text(
+                                    '${user.age}세',
+                                    style: const TextStyle(
+                                      fontSize: 16,
+                                      color: Colors.black54,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            );
+                          },
                         ),
                         const SizedBox(height: 5),
                         if (user.nativeLanguage != null &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   easy_image_viewer: ^1.5.1
   emoji_picker_flutter: ^4.3.0
   firebase_analytics: ^11.4.6
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_native_splash: ^2.3.10


### PR DESCRIPTION
- 로그인 시 이용약관 및 개인정보처리방침 동의 팝업 로직을 OnBoardingPage에서 LoginPage로 이동
- SharedPreferences를 통해 동의 여부를 확인하고, 중복 팝업 방지
- 설정 페이지에 '이용약관' 및 '개인정보처리방침' 항목 추가
- 추천, 동급생, 근처 탭에서 자신의 게시글이 보이지 않도록 필터링 처리
- 댓글 카드 디자인 개선: 배경 색상과 여백 수정, 아이콘을 CupertinoIcons.ellipsis로 교체
- 프로필 레이아웃에서 나이 정보를 이름 옆으로 다시 이동하며 overflow 오류 수정